### PR TITLE
fix(slider): fix min and max value for slider

### DIFF
--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -31,7 +31,7 @@ class ConnectedFilter extends React.Component {
     )
       .then((res) => {
         this.handleReceiveNewAggsData(res.data._aggregation[this.props.guppyConfig.type]);
-        this.saveInitialAggsData(res.data._aggregation);
+        this.saveInitialAggsData(res.data._aggregation[this.props.guppyConfig.type]);
       });
   }
 

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -10,6 +10,7 @@ const getSingleFilterOption = (histogramResult, initHistogramRes) => {
   if (!histogramResult || !histogramResult.histogram) {
     throw new Error(`Error parsing field options ${JSON.stringify(histogramResult)}`);
   }
+  // if this is for range slider
   if (histogramResult.histogram.length === 1 && (typeof histogramResult.histogram[0].key) !== 'string') {
     const rangeOptions = histogramResult.histogram.map((item) => {
       const minValue = initHistogramRes ? initHistogramRes.histogram[0].key[0] : item.key[0];


### PR DESCRIPTION
Range slider should remember initial min/max value even user drag then. There was a bug in ConnectedFilter and this PR fixes it. 

### New Features


### Breaking Changes


### Bug Fixes
 - fix min and max value for slider

### Improvements


### Dependency updates


### Deployment changes

