### PR TITLE
fix(array): deal with empty config index

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -1,0 +1,14 @@
+{
+  "indices": [
+    {
+      "index": "gen3-dev-subject",
+      "type": "subject"
+    },
+    {
+      "index": "gen3-dev-file",
+      "type": "file"
+    }
+  ],
+  "configIndex": "gen3-dev-config",
+  "auth_filter_field": "gen3_resource_path"
+}

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -21,7 +21,7 @@ const config = {
         type: 'file',
       },
     ],
-    configIndex: inputConfig.configIndex || 'gen3-dev-config',
+    configIndex: inputConfig.configIndex,
     authFilterField: inputConfig.auth_filter_field || 'gen3_resource_path',
   },
 

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -164,6 +164,10 @@ class ES {
   }
 
   async _getArrayFieldsFromConfigIndex() {
+    if (typeof this.config.configIndex === 'undefined') {
+      log.info('[ES.initialize] no array fields from es config index.');
+      return Promise.resolve({});
+    }
     const arrayFields = {};
     log.info('[ES.initialize] getting array fields from es config index...');
     return this.client.search({

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -182,6 +182,10 @@ class ES {
             if (twoParts.length !== 2) return;
             const index = twoParts[0];
             const field = twoParts[1];
+            if (!this.fieldTypes || !this.fieldTypes[index] || !this.fieldTypes[index][field]) {
+              const errMsg = `[ES.initialize] wrong array entry from config index: index "${index}" or field "${field}" not found.`;
+              throw new Error(errMsg);
+            }
             if (!arrayFields[index]) arrayFields[index] = [];
             arrayFields[index].push(field);
           }
@@ -189,7 +193,7 @@ class ES {
         log.info('[ES.initialize] got array fields from es config index:');
         log.rawOutput(JSON.stringify(arrayFields, null, 4));
       } catch (err) {
-        log.error('[ES.initialize] Error while getting array fields from config index');
+        throw new Error(err);
       }
       return arrayFields;
     }, (err) => {


### PR DESCRIPTION
This PR deals with empty config index: if no config index is set, we don't get array index from ES

### New Features


### Breaking Changes


### Bug Fixes
  - deal with empty config index

### Improvements


### Dependency updates


### Deployment changes

