### PR TITLE
Feat/field names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,9 +1214,9 @@
       "dev": true
     },
     "@gen3/ui-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.2.0.tgz",
-      "integrity": "sha512-dsPTPBkSugACa3EPgw+o0a/sCR/HT9kFwCJzl7xxox+6BuIGtDM10nXXRDmbRZEcMKr6pihPO3qOR6bpL00Gww==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.2.1.tgz",
+      "integrity": "sha512-WulP8MNtT8Xk21OnWNEQNDCZPF+o7SkmtwkH8SnSHyGCmSkB61NZRjFqSO724ffpncBOD0Z08UySon6xqdHznQ==",
       "requires": {
         "babel-loader": "^8.0.5",
         "postcss-loader": "^3.0.0",
@@ -6459,24 +6459,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6486,12 +6490,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -6500,34 +6506,40 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6536,25 +6548,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6563,13 +6579,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6585,7 +6603,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6599,13 +6618,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6614,7 +6635,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6623,7 +6645,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6633,18 +6656,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -6652,13 +6678,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -6666,12 +6694,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -6680,7 +6710,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6689,7 +6720,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6697,13 +6729,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6714,7 +6748,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6732,7 +6767,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6742,13 +6778,15 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6758,7 +6796,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6770,18 +6809,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -6789,19 +6831,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6811,19 +6856,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6835,7 +6883,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -6843,7 +6892,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6858,7 +6908,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6867,42 +6918,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -6912,7 +6970,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6921,7 +6980,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6929,13 +6989,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6950,13 +7012,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6965,12 +7029,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -7637,9 +7703,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.0.tgz",
-      "integrity": "sha512-dJEmMwloo0gq40chdtDmE4tMp67ZGwN7MFTgjNqWi2VHEi5Ya6JkuvPWasjcAIm7lg+2if8xxn5R199wspcplg=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.1.tgz",
+      "integrity": "sha512-DWjnQIFLenVrwyRCKZT+7a7/U4Cqgar4WG8V++K3hw+lrW1hc/SIwdiGmtxKCVACmHULTuGeBbHJmbwW7/sAvA=="
     },
     "ignore-by-default": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/uc-cdis/guppy#readme",
   "dependencies": {
     "@elastic/elasticsearch": "^7.0.0-rc.1",
-    "@gen3/ui-component": "0.2.0",
+    "@gen3/ui-component": "0.2.1",
     "apollo-server": "^2.4.8",
     "apollo-server-express": "^2.4.8",
     "body-parser": "^1.18.3",

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import FilterGroup from '@gen3/ui-component/dist/components/filters/FilterGroup';
 import FilterList from '@gen3/ui-component/dist/components/filters/FilterList';
 import {
-  getFilterGroupConfig,
   getFilterSections,
   excludeSelfFilterFromAggsData,
 } from './utils';
@@ -53,10 +52,11 @@ class ConnectedFilter extends React.Component {
   }
 
   updateTabs(tabsOptions) {
-    const tabs = this.props.filterConfig.tabs.map(({ filters }, index) => (
+    const { fieldMapping } = this.props;
+    const tabs = this.props.filterConfig.tabs.map(({ fields }, index) => (
       <FilterList
         key={index}
-        sections={getFilterSections(filters, tabsOptions, this.state.initialAggsData)}
+        sections={getFilterSections(fields, fieldMapping, tabsOptions, this.state.initialAggsData)}
       />
     ));
     this.setState({ tabs });
@@ -88,7 +88,7 @@ class ConnectedFilter extends React.Component {
       <FilterGroup
         className={this.props.className}
         tabs={this.state.tabs}
-        filterConfig={getFilterGroupConfig(this.props.filterConfig)}
+        filterConfig={this.props.filterConfig}
         onFilterChange={e => this.handleFilterChange(e)}
         hideZero={this.props.hideZero}
       />
@@ -100,10 +100,7 @@ ConnectedFilter.propTypes = {
   filterConfig: PropTypes.shape({
     tabs: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string,
-      filters: PropTypes.arrayOf(PropTypes.shape({
-        field: PropTypes.string,
-        label: PropTypes.string,
-      })),
+      fields: PropTypes.arrayOf(PropTypes.string),
     })),
   }).isRequired,
   guppyConfig: PropTypes.shape({
@@ -114,6 +111,10 @@ ConnectedFilter.propTypes = {
   onReceiveNewAggsData: PropTypes.func,
   hideZero: PropTypes.bool,
   className: PropTypes.string,
+  fieldMapping: PropTypes.arrayOf(PropTypes.shape({
+    field: PropTypes.string,
+    name: PropTypes.string,
+  })),
 };
 
 ConnectedFilter.defaultProps = {
@@ -121,6 +122,7 @@ ConnectedFilter.defaultProps = {
   onReceiveNewAggsData: () => {},
   hideZero: true,
   className: '',
+  fieldMapping: [],
 };
 
 export default ConnectedFilter;

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -35,14 +35,23 @@ const getSingleFilterOption = (histogramResult, initHistogramRes) => {
   return textOptions;
 };
 
-export const getFilterSections = (filters, tabsOptions, initialTabsOptions) => {
-  const sections = filters.map(({ field, label }) => ({
-    title: label,
-    options: getSingleFilterOption(
-      tabsOptions[field],
-      initialTabsOptions ? initialTabsOptions[field] : undefined,
-    ),
-  }));
+const capitalizeFirstLetter = (str) => {
+  const res = str.replace(/_/gi, ' ');
+  return res.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+};
+
+export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabsOptions) => {
+  const sections = fields.map((field) => {
+    const overrideName = fieldMapping.find(entry => (entry.field === field));
+    const label = overrideName ? overrideName.name : capitalizeFirstLetter(field);
+    return {
+      title: label,
+      options: getSingleFilterOption(
+        tabsOptions[field],
+        initialTabsOptions ? initialTabsOptions[field] : undefined,
+      ),
+    };
+  });
   return sections;
 };
 

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -4,6 +4,7 @@ import {
   askGuppyForRawData,
   downloadDataFromGuppy,
   askGuppyForTotalCounts,
+  getAllFieldsFromGuppy,
 } from '../Utils/queries';
 
 /**
@@ -46,13 +47,29 @@ class GuppyWrapper extends React.Component {
       filter: {},
       rawData: [],
       totalCount: 0,
+      allFields: [],
     };
   }
 
   componentDidMount() {
     this.getDataFromGuppy(this.props.rawDataFields, undefined, true);
+    getAllFieldsFromGuppy(
+      this.props.guppyConfig.path,
+      this.props.guppyConfig.type,
+    ).then((fields) => {
+      this.setState({ allFields: fields });
+    });
   }
 
+  /**
+   * This function get data with current filter (if any),
+   * and update this.state.rawData and this.state.totalCount
+   * @param {string[]} fields
+   * @param {object} sort
+   * @param {bool} updateDataWhenReceive
+   * @param {number} offset
+   * @param {number} size
+   */
   getDataFromGuppy(fields, sort, updateDataWhenReceive, offset, size) {
     return askGuppyForRawData(
       this.props.guppyConfig.path,
@@ -186,6 +203,7 @@ class GuppyWrapper extends React.Component {
             fetchAndUpdateRawData: this.handleFetchAndUpdateRawData.bind(this),
             downloadRawData: this.handleDownloadRawData.bind(this),
             downloadRawDataByFields: this.handleDownloadRawDataByFields.bind(this),
+            allFields: this.state.allFields,
 
             // a callback function which return total counts for any type, with any filter
             getTotalCountsByTypeAndFilter: this.handleAskGuppyForTotalCounts.bind(this),

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -134,7 +134,7 @@ export const askGuppyForRawData = (
 };
 
 export const getAllFieldsFromFilterConfigs = filterTabConfigs => filterTabConfigs
-  .reduce((acc, cur) => acc.concat(cur.filters.map(item => item.field)), []);
+  .reduce((acc, cur) => acc.concat(cur.fields), []);
 
 /**
  * Download all data from guppy using fields, filter, and sort args.

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -257,7 +257,7 @@ export const numericAggregation = async (
   return [result];
 };
 
-const PAGE_SIZE = 1024;
+const PAGE_SIZE = 3;
 export const textAggregation = async (
   {
     esInstance,
@@ -305,7 +305,9 @@ export const textAggregation = async (
       });
       resultSize += 1;
     });
-    queryBody.aggs[aggsName].composite.after = result.aggregations[aggsName].after_key;
+    const afterKey = result.aggregations[aggsName].after_key;
+    if (typeof afterKey === 'undefined') break;
+    queryBody.aggs[aggsName].composite.after = afterKey;
   } while (resultSize === PAGE_SIZE);
   /* eslint-enable */
   return finalResults;

--- a/stories/conf.js
+++ b/stories/conf.js
@@ -1,27 +1,26 @@
 export const filterConfig = {
     tabs: [{
       title: 'Project',
-      filters: [
-        { field: 'project', label: 'Project' },
-        { field: 'study', label: 'Study' },
+      fields: [
+        'project',
+        'study',
       ],
     },
     {
       title: 'Subject',
-      filters: [
-        { field: 'race', label: 'Race' },
-        { field: 'ethnicity', label: 'Ethnicity' },
-        { field: 'gender', label: 'Gender' },
-        { field: 'vital_status', label: 'Vital_status' },
-        //{ field: 'whatever_lab_result_value', label: 'Lab Result Value' },
+      fields: [
+        'race',
+        'ethnicity',
+        'gender',
+        'vital_status',
       ],
     },
     {
       title: 'File',
-      filters: [
-        { field: 'file_count', label: 'File_count' },
-        { field: 'file_type', label: 'File_type' },
-        { field: 'file_format', label: 'File_format' },
+      fields: [
+        'file_count',
+        'file_type',
+        'file_format',
       ],
     }],
   };
@@ -44,3 +43,10 @@ export const filterConfig = {
     type: 'subject',
     fileType: 'file',
   };
+
+  export const fieldMapping = [
+    {
+      field: 'project',
+      name: 'Project Name',
+    },
+  ];

--- a/stories/connectedFilter.jsx
+++ b/stories/connectedFilter.jsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import ConnectedFilter from '../src/components/ConnectedFilter';
 import './guppyWrapper.css';
-import {filterConfig, guppyConfig} from './conf';
+import { filterConfig, guppyConfig, fieldMapping } from './conf';
 
 storiesOf('ConnectedFilter', module)
   .add('Filter', () => {
@@ -12,6 +12,7 @@ storiesOf('ConnectedFilter', module)
         filterConfig={filterConfig}
         guppyConfig={guppyConfig}
         onFilterChange={action('filter change')}
+        fieldMapping={fieldMapping}
       />
     );
   });

--- a/stories/connectedTable.jsx
+++ b/stories/connectedTable.jsx
@@ -5,7 +5,7 @@ import ConnectedFilter from '../src/components/ConnectedFilter';
 import GuppyWrapper from '../src/components/GuppyWrapper';
 import TableExample from './TableExample';
 import './guppyWrapper.css';
-import {filterConfig, guppyConfig, tableConfig} from './conf';
+import { filterConfig, guppyConfig, tableConfig } from './conf';
 
 storiesOf('Guppy Wrapper', module)
   .add('Connected Filter and Table', () => {


### PR DESCRIPTION
This PR makes `GuppyWrapper` pass `allFields` props to its children component. And `ConnectedFilter` will take in `fieldMapping` props as an override to field names in filter. 
As a result, our components from windmill won't need to give all field names to GuppyWrapper, Guppy will use default `capitalizeFirstLetter` to humanize field names for filters. 

### New Features


### Breaking Changes
 - Make GuppyWrapper pass `allFields` props to children
 - Change ConnectedFilter's `filterConfig` prop type, and let it humanize field names instead of reading in fieldMapping for names. 

### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

