### PR TITLE
feat(whitelist): add whitelist to tieraccess middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For example `regular` leveled commons with config looks like this will skip encr
 }
 ```
 
-By default the whitelist contains missing values: ['\__missing\__', 'unknown', 'not reported', 'no data']. 
+By default the whitelist contains missing values: ['\__missing__', 'unknown', 'not reported', 'no data']. 
 If you would like to disable whitelist, simply put `encrypt_whitelist: "disabled"` in your config.
 
 For example following script will start a Guppy server with `regular` tier access level, and minimum visible count set to 100: 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For example `regular` leveled commons with config looks like this will skip encr
 }
 ```
 
-By default the whitelist contains missing values: ['\__missing__', 'unknown', 'not reported', 'no data']. 
+By default the whitelist contains missing values: ['\_\_missing\_\_', 'unknown', 'not reported', 'no data']. 
 If you would like to disable whitelist, simply put `encrypt_whitelist: "disabled"` in your config.
 
 For example following script will start a Guppy server with `regular` tier access level, and minimum visible count set to 100: 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For example `regular` leveled commons with config looks like this will skip encr
 }
 ```
 
-By default the whitelist contains missing values: ['__missing__', 'unknown', 'not reported', 'no data']. 
+By default the whitelist contains missing values: ['\__missing\__', 'unknown', 'not reported', 'no data']. 
 If you would like to disable whitelist, simply put `encrypt_whitelist: "disabled"` in your config.
 
 For example following script will start a Guppy server with `regular` tier access level, and minimum visible count set to 100: 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For example `regular` leveled commons with config looks like this will skip encr
 ```
 
 By default the whitelist contains missing values: ['\_\_missing\_\_', 'unknown', 'not reported', 'no data']. 
-If you would like to disable whitelist, simply put `encrypt_whitelist: "disabled"` in your config.
+If you would like to disable whitelist, simply put `enable_encrypt_whitelist: false` in your config.
 
 For example following script will start a Guppy server with `regular` tier access level, and minimum visible count set to 100: 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,29 @@ Guppy also support 3 different levels of tier access, by setting `TIER_ACCESS_LE
 
 For `regular` level, there's another configuration environment variable `TIER_ACCESS_LIMIT`, which is the minimum visible count for aggregation results.
 
+`regular` level commons could also take in a whitelist of values that won't be encrypted. It is set by `config.encrypt_whitelist`. 
+For example `regular` leveled commons with config looks like this will skip encrypting value `do-not-encrypt-me` even if its count is less than `TIER_ACCESS_LIMIT`: 
+
+```
+{
+  "indices": [
+    {
+      "index": "gen3-dev-subject",
+      "type": "subject"
+    },
+    {
+      "index": "gen3-dev-file",
+      "type": "file"
+    }
+  ],
+  "config_index": "gen3-dev-config",
+  "auth_filter_field": "gen3_resource_path",
+  "encrypt_whitelist": [ "do-not-encrypt-me" ]
+}
+```
+
+By default the whitelist contains missing values: ['__missing__', 'unknown', 'not reported', 'no data']. 
+If you would like to disable whitelist, simply put `encrypt_whitelist: "disabled"` in your config.
 
 For example following script will start a Guppy server with `regular` tier access level, and minimum visible count set to 100: 
 

--- a/devHelper/scripts/commands.sh
+++ b/devHelper/scripts/commands.sh
@@ -129,12 +129,12 @@ declare -a vitalList
 declare -a fileTypeList
 declare -a fileFormat
 
-genderList=( male female )
-ethnicityList=( 'American Indian' 'Pacific Islander' 'Black' 'Multi-racial' 'White' 'Haspanic' )
-raceList=( white black hispanic asian mixed )
-vitalList=( Alive Dead )
-fileTypeList=( "mRNA Array" "Unaligned Reads" "Lipdomic MS" "Protionic MS" "1Gs Ribosomes")
-fileFormatList=( BEM BAM BED CSV FASTQ RAW TAR TSV TXT IDAT )
+genderList=( "male" "female" "unknown")
+ethnicityList=( "American Indian" "Pacific Islander" "Black" "Multi-racial" "White" "Haspanic" "__missing__" )
+raceList=( "white" "black" "hispanic" "asian" "mixed" "not reported" )
+vitalList=( "Alive" "Dead" "no data" )
+fileTypeList=( "mRNA Array" "Unaligned Reads" "Lipdomic MS" "Protionic MS" "1Gs Ribosomes" "Unknown" )
+fileFormatList=( "BEM" "BAM" "BED" "CSV" "FASTQ" "RAW" "TAR" "TSV" "TXT" "IDAT" "__missing__" )
 resourceList=( "/programs/jnkns/projects/jenkins" "/programs/DEV/projects/test" "/programs/external/projects/test")
 projectList=( "jnkns-jenkins" "DEV-test" "external-test" )
 

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -31,6 +31,7 @@ const config = {
   tierAccessLevel: 'private',
   tierAccessLimit: 1000,
   logLevel: 'INFO',
+  encryptWhitelist: inputConfig.encrypt_whitelist || ['__missing__', 'unknown', 'not reported', 'no data'],
 };
 
 if (process.env.GEN3_ES_ENDPOINT) {
@@ -68,6 +69,13 @@ if (process.env.TIER_ACCESS_LEVEL) {
     throw new Error(`Invalid TIER_ACCESS_LEVEL "${process.env.TIER_ACCESS_LEVEL}"`);
   }
   config.tierAccessLevel = process.env.TIER_ACCESS_LEVEL;
+}
+
+// check whitelist is disabled
+if (config.encryptWhitelist === 'disabled') {
+  config.encryptWhitelist = [];
+} else if (typeof config.encryptWhitelist !== 'object') {
+  config.encryptWhitelist = [config.encryptWhitelist];
 }
 
 log.setLogLevel(config.logLevel);

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -31,6 +31,7 @@ const config = {
   tierAccessLevel: 'private',
   tierAccessLimit: 1000,
   logLevel: 'INFO',
+  enableEncryptWhiteList: typeof inputConfig.enable_encrypt_whitelist === 'undefined' ? true : inputConfig.enable_encrypt_whitelist,
   encryptWhitelist: inputConfig.encrypt_whitelist || ['__missing__', 'unknown', 'not reported', 'no data'],
 };
 
@@ -71,11 +72,13 @@ if (process.env.TIER_ACCESS_LEVEL) {
   config.tierAccessLevel = process.env.TIER_ACCESS_LEVEL;
 }
 
-// check whitelist is disabled
-if (config.encryptWhitelist === 'disabled') {
+// check whitelist is enabled
+if (config.enableEncryptWhiteList) {
+  if (typeof config.encryptWhitelist !== 'object') {
+    config.encryptWhitelist = [config.encryptWhitelist];
+  }
+} else {
   config.encryptWhitelist = [];
-} else if (typeof config.encryptWhitelist !== 'object') {
-  config.encryptWhitelist = [config.encryptWhitelist];
 }
 
 log.setLogLevel(config.logLevel);

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -34,6 +34,7 @@ log.levelEnums = {
   SILENT: 5,
 };
 
+log.setLevel('INFO');
 log.setLogLevel = (level) => {
   if (!Object.keys(numLevels).includes(level) && !Object.keys(log.levelEnums).includes(level)) {
     throw new Error(`Invalid log level ${level}`);

--- a/src/server/middlewares/tierAccessMiddleware/index.js
+++ b/src/server/middlewares/tierAccessMiddleware/index.js
@@ -4,7 +4,7 @@ import log from '../../logger';
 import config from '../../config';
 import esInstance from '../../es/index';
 import CodedError from '../../utils/error';
-import { firstLetterUpperCase } from '../../utils/utils';
+import { firstLetterUpperCase, isWhitelisted } from '../../utils/utils';
 
 const ENCRYPT_COUNT = -1;
 
@@ -117,7 +117,11 @@ const hideNumberResolver = isGettingTotalCount => async (resolve, root, args, co
   if (isGettingTotalCount) {
     return (result < config.tierAccessLimit) ? ENCRYPT_COUNT : result;
   }
+
   const encryptedResult = result.map((item) => {
+    if (isWhitelisted(item.key)) { // we don't excrypt whitelisted results
+      return item;
+    }
     if (item.count < config.tierAccessLimit) {
       return {
         key: item.key,

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -1,6 +1,6 @@
-export const firstLetterUpperCase = str => str.charAt(0).toUpperCase() + str.slice(1);
+import config from '../config';
 
-export const test = 1;
+export const firstLetterUpperCase = str => str.charAt(0).toUpperCase() + str.slice(1);
 
 /**
  * transfer '/programs/DEV/projects/test' to 'DEV-test'
@@ -26,4 +26,15 @@ export const addTwoFilters = (filter1, filter2) => {
     ],
   };
   return appliedFilter;
+};
+
+export const isWhitelisted = (key) => {
+  const lowerCasedWhitelist = config.encryptWhitelist.map((w) => {
+    if (typeof w === 'string') {
+      return w.toLowerCase();
+    }
+    return w;
+  });
+  const lowerCasedKey = (typeof key === 'string') ? key.toLowerCase() : key;
+  return lowerCasedWhitelist.includes(lowerCasedKey);
 };


### PR DESCRIPTION
Add whitelist to tieraccess middleware that will skip encrypting some values. See README for detail. 

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
  - add whitelist to tieraccess middleware that will skip encrypting some values

### Dependency updates


### Deployment changes

