### PR TITLE
fix(array): change array config by doc

### DIFF
--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -182,11 +182,20 @@ class ES {
       log.info('[ES.initialize] no array fields from es config index.');
       return Promise.resolve({});
     }
+    if (!this.fieldTypes) {
+      return {};
+    }
     const arrayFields = {};
     log.info(`[ES.initialize] getting array fields from es config index "${this.config.configIndex}"...`);
     return this.client.search({
       index: this.config.configIndex,
-      body: { query: { match_all: {} } },
+      body: {
+        query: {
+          ids: {
+            values: Object.keys(this.fieldTypes),
+          },
+        },
+      },
     }).then((resp) => {
       try {
         resp.body.hits.hits.forEach((doc) => {


### PR DESCRIPTION
We just decide to change array config format: now array fields are grouped and stored by index as a doc in array config, and we set _id as index name for this doc.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
  - change array config format to store by doc

### Dependency updates


### Deployment changes

