### PR TITLE
fix(order): order aggregation result by doc count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -321,7 +321,7 @@ export const textAggregation = async (
     },
   };
   let resultSize;
-  const finalResults = [];
+  let finalResults = [];
   /* eslint-disable */
   do {
     const result = await esInstance.query(esIndex, esType, queryBody); 
@@ -339,6 +339,9 @@ export const textAggregation = async (
     queryBody.aggs[aggsName].composite.after = afterKey;
   } while (resultSize === PAGE_SIZE);
   /* eslint-enable */
+
+  // order aggregations by doc count
+  finalResults = finalResults.sort((e1, e2) => e2.count - e1.count);
 
   // make the missing data bucket to the bottom of the list
   if (config.esConfig.aggregationIncludeMissingData) {


### PR DESCRIPTION
This PR changes aggregation results to be ordered by doc count

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
  - Order aggregation result by doc count

### Dependency updates


### Deployment changes

