### PR TITLE
feat(unity): support customizing Arborist

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ You could set the endpoint by:
 export GEN3_ARBORIST_ENDPOINT=${arborist_service}
 ```
 
-If not set, Guppy will skip all authorization steps as default. 
-But if you just want to mock your own authorization behavior for local test without Arborist, just set `INTERNAL_LOCAL_TEST=true`. 
-Please look into `/src/server/utils/accessibilities.js` for more details. 
+If not set, it would default to `http://arborist-service`. You could set it to `mock` to
+skip all authorization steps. But if you just want to mock your own authorization
+behavior for local test without Arborist, just set `INTERNAL_LOCAL_TEST=true`. Please
+look into `/src/server/auth/utils.js` for more details.
 
 #### Tier access
 Guppy also support 3 different levels of tier access, by setting `TIER_ACCESS_LEVEL`: 

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -29,7 +29,7 @@ const config = {
 
   port: 80,
   path: '/graphql',
-  arboristEndpoint: 'mock',
+  arboristEndpoint: 'http://arborist-service',
   tierAccessLevel: 'private',
   tierAccessLimit: 1000,
   logLevel: 'INFO',
@@ -46,10 +46,6 @@ if (!config.esConfig.host.startsWith('http')) {
 
 if (process.env.GEN3_ARBORIST_ENDPOINT) {
   config.arboristEndpoint = process.env.GEN3_ARBORIST_ENDPOINT;
-}
-
-if (process.env.GEN3_ARBORIST_ENDPOINT_OVERRIDE) {
-  config.arboristEndpoint = process.env.GEN3_ARBORIST_ENDPOINT_OVERRIDE;
 }
 
 if (process.env.GUPPY_PORT) {

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -48,6 +48,10 @@ if (process.env.GEN3_ARBORIST_ENDPOINT) {
   config.arboristEndpoint = process.env.GEN3_ARBORIST_ENDPOINT;
 }
 
+if (process.env.GEN3_ARBORIST_ENDPOINT_OVERRIDE) {
+  config.arboristEndpoint = process.env.GEN3_ARBORIST_ENDPOINT_OVERRIDE;
+}
+
 if (process.env.GUPPY_PORT) {
   config.port = process.env.GUPPY_PORT;
 }


### PR DESCRIPTION
Because the behavior of the existing GEN3_ARBORIST_ENDPOINT defaults to mock if not set, a new OVERRIDE is needed to avoid changing this. If the new OVERRIDE is not set, it defaults to GEN3_ARBORIST_ENDPOINT which might be just http://arborist-service.

See also: https://github.com/uc-cdis/cloud-automation/pull/869/files#diff-ff1d8822f6c3ba09ea41626908560a26

### Improvements
- added `GEN3_ARBORIST_ENDPOINT_OVERRIDE`
