### PR TITLE
Feat/nested aggs query

### DIFF
--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -4,6 +4,7 @@ import mockTextAggs from './mockESData/mockTextAggs';
 import mockNumericAggsGlobalStats from './mockESData/mockNumericAggsGlobalStats';
 import mockHistogramFixWidth from './mockESData/mockNumericHistogramFixWidth';
 import mockHistogramFixBinCount from './mockESData/mockNumericHistogramFixBinCount';
+import mockNestedAggs from './mockESData/mockNestedAggs';
 
 const mockPing = () => {
   nock(config.esConfig.host)
@@ -277,6 +278,7 @@ const setup = () => {
   mockNumericAggsGlobalStats();
   mockHistogramFixWidth();
   mockHistogramFixBinCount();
+  mockNestedAggs();
 };
 
 export default setup;

--- a/src/server/__mocks__/mockESData/mockNestedAggs.js
+++ b/src/server/__mocks__/mockESData/mockNestedAggs.js
@@ -1,0 +1,292 @@
+import mockSearchEndpoint from './utils';
+
+const mockNestedAggs = () => {
+  // only missing fields in nestedAggFields variables
+  const missingAggsQuery = {
+    size: 0,
+    aggs: {
+      projectAggs: {
+        composite: {
+          sources: [
+            {
+              project: {
+                terms: {
+                  field: 'project',
+                  missing: 'no data',
+                },
+              },
+            },
+          ],
+          size: 10000,
+        },
+        aggs: {
+          someNonExistingFieldMissing: {
+            missing: {
+              field: 'someNonExistingField',
+            },
+          },
+          genderMissing: {
+            missing: {
+              field: 'gender',
+            },
+          },
+        },
+      },
+    },
+  };
+  const fakeMissingAggs = {
+    aggregations: {
+      projectAggs: {
+        after_key: {
+          project: 'internal-project-2',
+        },
+        buckets: [
+          {
+            key: {
+              project: 'internal-project-1',
+            },
+            doc_count: 41,
+            genderMissing: {
+              doc_count: 0,
+            },
+            someNonExistingFieldMissing: {
+              doc_count: 41,
+            },
+          },
+          {
+            key: {
+              project: 'internal-project-2',
+            },
+            doc_count: 35,
+            genderMissing: {
+              doc_count: 0,
+            },
+            someNonExistingFieldMissing: {
+              doc_count: 35,
+            },
+          },
+        ],
+      },
+    },
+  };
+  mockSearchEndpoint(missingAggsQuery, fakeMissingAggs);
+
+  // only terms fields in nestedAggFields variables
+  const termsAggsQuery = {
+    size: 0,
+    aggs: {
+      projectAggs: {
+        composite: {
+          sources: [
+            {
+              project: {
+                terms: {
+                  field: 'project',
+                  missing: 'no data',
+                },
+              },
+            },
+          ],
+          size: 10000,
+        },
+        aggs: {
+          genderTerms: {
+            terms: {
+              field: 'gender',
+            },
+          },
+          someNonExistingFieldTerms: {
+            terms: {
+              field: 'someNonExistingField',
+            },
+          },
+        },
+      },
+    },
+  };
+  const fakeTermsAggs = {
+    aggregations: {
+      projectAggs: {
+        after_key: {
+          project: 'internal-project-2',
+        },
+        buckets: [
+          {
+            key: {
+              project: 'internal-project-1',
+            },
+            doc_count: 41,
+            genderTerms: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 0,
+              buckets: [
+                {
+                  key: 'male',
+                  doc_count: 22,
+                },
+                {
+                  key: 'unknown',
+                  doc_count: 10,
+                },
+                {
+                  key: 'female',
+                  doc_count: 9,
+                },
+              ],
+            },
+            someNonExistingFieldTerms: {
+              buckets: [],
+            },
+          },
+          {
+            key: {
+              project: 'internal-project-2',
+            },
+            doc_count: 35,
+            genderTerms: {
+              buckets: [
+                {
+                  key: 'male',
+                  doc_count: 13,
+                },
+                {
+                  key: 'female',
+                  doc_count: 11,
+                },
+                {
+                  key: 'unknown',
+                  doc_count: 11,
+                },
+              ],
+            },
+            someNonExistingFieldTerms: {
+              buckets: [],
+            },
+          },
+
+        ],
+      },
+    },
+  };
+  mockSearchEndpoint(termsAggsQuery, fakeTermsAggs);
+
+  // combined missing and terms fields in nestedAggFields variables
+  const combinedAggsQuery = {
+    size: 0,
+    aggs: {
+      projectAggs: {
+        composite: {
+          sources: [
+            {
+              project: {
+                terms: {
+                  field: 'project',
+                  missing: 'no data',
+                },
+              },
+            },
+          ],
+          size: 10000,
+        },
+        aggs: {
+          genderMissing: {
+            missing: {
+              field: 'gender',
+            },
+          },
+          someNonExistingFieldMissing: {
+            missing: {
+              field: 'someNonExistingField',
+            },
+          },
+          genderTerms: {
+            terms: {
+              field: 'gender',
+            },
+          },
+          someNonExistingFieldTerms: {
+            terms: {
+              field: 'someNonExistingField',
+            },
+          },
+        },
+      },
+    },
+  };
+  const combinedTermsAggs = {
+    aggregations: {
+      projectAggs: {
+        after_key: {
+          project: 'internal-project-2',
+        },
+        buckets: [
+          {
+            key: {
+              project: 'internal-project-1',
+            },
+            doc_count: 41,
+            genderTerms: {
+              buckets: [
+                {
+                  key: 'male',
+                  doc_count: 22,
+                },
+                {
+                  key: 'unknown',
+                  doc_count: 10,
+                },
+                {
+                  key: 'female',
+                  doc_count: 9,
+                },
+              ],
+            },
+            someNonExistingFieldTerms: {
+              buckets: [],
+            },
+            genderMissing: {
+              doc_count: 0,
+            },
+            someNonExistingFieldMissing: {
+              doc_count: 41,
+            },
+          },
+          {
+            key: {
+              project: 'internal-project-2',
+            },
+            doc_count: 35,
+            genderTerms: {
+              buckets: [
+                {
+                  key: 'male',
+                  doc_count: 13,
+                },
+                {
+                  key: 'female',
+                  doc_count: 11,
+                },
+                {
+                  key: 'unknown',
+                  doc_count: 11,
+                },
+              ],
+            },
+            someNonExistingFieldTerms: {
+              buckets: [],
+            },
+            genderMissing: {
+              doc_count: 0,
+            },
+            someNonExistingFieldMissing: {
+              doc_count: 35,
+            },
+          },
+        ],
+      },
+    },
+  };
+  mockSearchEndpoint(combinedAggsQuery, combinedTermsAggs);
+};
+
+export default mockNestedAggs;

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -76,11 +76,13 @@ describe('Schema', () => {
       subject (
         filter: JSON, 
         filterSelf: Boolean=true, 
+        nestedAggFields:JSON,
         accessibility: Accessibility=all
       ): SubjectAggregation
       file (
         filter: JSON, 
         filterSelf: Boolean=true, 
+        nestedAggFields:JSON,
         accessibility: Accessibility=all
       ): FileAggregation
     }`;

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -32,7 +32,7 @@ const config = {
   arboristEndpoint: 'http://arborist-service',
   tierAccessLevel: 'private',
   tierAccessLimit: 1000,
-  logLevel: 'DEBUG',
+  logLevel: 'INFO',
   enableEncryptWhiteList: typeof inputConfig.enable_encrypt_whitelist === 'undefined' ? true : inputConfig.enable_encrypt_whitelist,
   encryptWhitelist: inputConfig.encrypt_whitelist || ['__missing__', 'unknown', 'not reported', 'no data'],
 };

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -32,7 +32,7 @@ const config = {
   arboristEndpoint: 'http://arborist-service',
   tierAccessLevel: 'private',
   tierAccessLimit: 1000,
-  logLevel: 'INFO',
+  logLevel: 'DEBUG',
   enableEncryptWhiteList: typeof inputConfig.enable_encrypt_whitelist === 'undefined' ? true : inputConfig.enable_encrypt_whitelist,
   encryptWhitelist: inputConfig.encrypt_whitelist || ['__missing__', 'unknown', 'not reported', 'no data'],
 };

--- a/src/server/es/__tests__/aggs.test.js
+++ b/src/server/es/__tests__/aggs.test.js
@@ -105,26 +105,18 @@ describe('could aggregate for text fields', () => {
       {
         key: 'unknown',
         count: 38,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'female',
         count: 35,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'male',
         count: 27,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'no data',
         count: 40,
-        missingFields: [],
-        termsFields: [],
       }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);
@@ -146,20 +138,14 @@ describe('could aggregate for text fields', () => {
       {
         key: 'female',
         count: 35,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'male',
         count: 27,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'no data',
         count: 40,
-        missingFields: [],
-        termsFields: [],
       }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);
@@ -181,26 +167,18 @@ describe('could aggregate for text fields', () => {
       {
         key: 'unknown',
         count: 38,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'female',
         count: 35,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'male',
         count: 27,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'no data',
         count: 40,
-        missingFields: [],
-        termsFields: [],
       }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);
@@ -222,26 +200,18 @@ describe('could aggregate for text fields', () => {
       {
         key: 'unknown',
         count: 19,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'female',
         count: 18,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'male',
         count: 15,
-        missingFields: [],
-        termsFields: [],
       },
       {
         key: 'no data',
         count: 20,
-        missingFields: [],
-        termsFields: [],
       }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);

--- a/src/server/es/__tests__/aggs.test.js
+++ b/src/server/es/__tests__/aggs.test.js
@@ -862,3 +862,240 @@ describe('could aggregate for numeric fields, fixed bin count', () => {
     expect(result).toEqual(expectedResults);
   });
 });
+
+// see /src/server/__mocks__/mockESData/mockNestedAggs.js for mock results
+describe('could only aggregate to find missing fields (both existing and non-existing fields)', () => {
+  test('nested missing-only aggregation', async () => {
+    await esInstance.initialize();
+    const field = 'project';
+    const nestedAggFields = {
+      missingFields: [
+        'gender',
+        'someNonExistingField',
+      ],
+    };
+    const result = await textAggregation(
+      { esInstance, esIndex, esType },
+      { field, nestedAggFields },
+    );
+    const expectedResults = [
+      {
+        key: 'internal-project-1',
+        count: 41,
+        missingFields: [
+          {
+            field: 'gender',
+            count: 0,
+          },
+          {
+            field: 'someNonExistingField',
+            count: 41,
+          },
+        ],
+      },
+      {
+        key: 'internal-project-2',
+        count: 35,
+        missingFields: [
+          {
+            field: 'gender',
+            count: 0,
+          },
+          {
+            field: 'someNonExistingField',
+            count: 35,
+          },
+        ],
+      },
+    ];
+    expect(result).toEqual(expectedResults);
+  });
+
+  test('nested terms-only aggregation', async () => {
+    await esInstance.initialize();
+    const field = 'project';
+    const nestedAggFields = {
+      termsFields: [
+        'gender',
+        'someNonExistingField',
+      ],
+    };
+    const result = await textAggregation(
+      { esInstance, esIndex, esType },
+      { field, nestedAggFields },
+    );
+    const expectedResults = [
+      {
+        key: 'internal-project-1',
+        count: 41,
+        termsFields: [
+          {
+            field: 'gender',
+            terms: [
+              {
+                key: 'male',
+                count: 22,
+              },
+              {
+                key: 'unknown',
+                count: 10,
+              },
+              {
+                key: 'female',
+                count: 9,
+              },
+            ],
+          },
+          {
+            field: 'someNonExistingField',
+            terms: [
+              {
+                key: null,
+                count: 0,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        key: 'internal-project-2',
+        count: 35,
+        termsFields: [
+          {
+            field: 'gender',
+            terms: [
+              {
+                key: 'male',
+                count: 13,
+              },
+              {
+                key: 'female',
+                count: 11,
+              },
+              {
+                key: 'unknown',
+                count: 11,
+              },
+            ],
+          },
+          {
+            field: 'someNonExistingField',
+            terms: [
+              {
+                key: null,
+                count: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(result).toEqual(expectedResults);
+  });
+
+  test('nested terms and missing combined aggregation', async () => {
+    await esInstance.initialize();
+    const field = 'project';
+    const nestedAggFields = {
+      missingFields: [
+        'gender',
+        'someNonExistingField',
+      ],
+      termsFields: [
+        'gender',
+        'someNonExistingField',
+      ],
+    };
+    const result = await textAggregation(
+      { esInstance, esIndex, esType },
+      { field, nestedAggFields },
+    );
+    const expectedResults = [
+      {
+        key: 'internal-project-1',
+        count: 41,
+        missingFields: [
+          {
+            field: 'gender',
+            count: 0,
+          },
+          {
+            field: 'someNonExistingField',
+            count: 41,
+          },
+        ],
+        termsFields: [
+          {
+            field: 'gender',
+            terms: [
+              {
+                key: 'male',
+                count: 22,
+              },
+              {
+                key: 'unknown',
+                count: 10,
+              },
+              {
+                key: 'female',
+                count: 9,
+              },
+            ],
+          },
+          {
+            field: 'someNonExistingField',
+            terms: [
+              {
+                key: null,
+                count: 0,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        key: 'internal-project-2',
+        count: 35,
+        missingFields: [
+          {
+            field: 'gender',
+            count: 0,
+          },
+          {
+            field: 'someNonExistingField',
+            count: 35,
+          },
+        ],
+        termsFields: [
+          {
+            field: 'gender',
+            terms: [
+              {
+                key: 'male',
+                count: 13,
+              },
+              {
+                key: 'female',
+                count: 11,
+              },
+              {
+                key: 'unknown',
+                count: 11,
+              },
+            ],
+          },
+          {
+            field: 'someNonExistingField',
+            terms: [
+              {
+                key: null,
+                count: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(result).toEqual(expectedResults);
+  });
+});

--- a/src/server/es/__tests__/aggs.test.js
+++ b/src/server/es/__tests__/aggs.test.js
@@ -102,10 +102,30 @@ describe('could aggregate for text fields', () => {
       { field },
     );
     const expectedResults = [
-      { key: 'unknown', count: 38 },
-      { key: 'female', count: 35 },
-      { key: 'male', count: 27 },
-      { key: 'no data', count: 40 }, // missing data always at end
+      {
+        key: 'unknown',
+        count: 38,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'female',
+        count: 35,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'male',
+        count: 27,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'no data',
+        count: 40,
+        missingFields: [],
+        termsFields: [],
+      }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);
   });
@@ -123,9 +143,24 @@ describe('could aggregate for text fields', () => {
       { filter, field },
     );
     const expectedResults = [
-      { key: 'female', count: 35 },
-      { key: 'male', count: 27 },
-      { key: 'no data', count: 40 }, // missing data always at end
+      {
+        key: 'female',
+        count: 35,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'male',
+        count: 27,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'no data',
+        count: 40,
+        missingFields: [],
+        termsFields: [],
+      }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);
   });
@@ -143,10 +178,30 @@ describe('could aggregate for text fields', () => {
       { filter, field, filterSelf: false },
     );
     const expectedResults = [
-      { key: 'unknown', count: 38 },
-      { key: 'female', count: 35 },
-      { key: 'male', count: 27 },
-      { key: 'no data', count: 40 }, // missing data always at end
+      {
+        key: 'unknown',
+        count: 38,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'female',
+        count: 35,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'male',
+        count: 27,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'no data',
+        count: 40,
+        missingFields: [],
+        termsFields: [],
+      }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);
   });
@@ -164,10 +219,30 @@ describe('could aggregate for text fields', () => {
       { field, defaultAuthFilter: authFilter },
     );
     const expectedResults = [
-      { key: 'unknown', count: 19 },
-      { key: 'female', count: 18 },
-      { key: 'male', count: 15 },
-      { key: 'no data', count: 20 }, // missing data always at end
+      {
+        key: 'unknown',
+        count: 19,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'female',
+        count: 18,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'male',
+        count: 15,
+        missingFields: [],
+        termsFields: [],
+      },
+      {
+        key: 'no data',
+        count: 20,
+        missingFields: [],
+        termsFields: [],
+      }, // missing data always at end
     ];
     expect(result).toEqual(expectedResults);
   });

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -362,9 +362,9 @@ export const textAggregation = async (
   {
     filter,
     field,
-    nestedAggFields,
     filterSelf,
     defaultAuthFilter,
+    nestedAggFields,
   },
 ) => {
   const queryBody = { size: 0 };
@@ -435,7 +435,7 @@ export const textAggregation = async (
         
     result.aggregations[aggsName].buckets.forEach((item) => {
       let missingFieldResult = []
-      if (nestedAggFields.missingFields) {
+      if (nestedAggFields && nestedAggFields.missingFields) {
         nestedAggFields.missingFields.forEach((element) => {
           missingFieldResult.push({
               field: element,
@@ -445,7 +445,7 @@ export const textAggregation = async (
         });
       }
       let termsFieldResult = []
-      if (nestedAggFields.termsFields) {
+      if (nestedAggFields && nestedAggFields.termsFields) {
         nestedAggFields.termsFields.forEach((element) => {
           let tempResult = {}
           tempResult.field = element

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -436,7 +436,7 @@ export const textAggregation = async (
     result.aggregations[aggsName].buckets.forEach((item) => {
       let missingFieldResult = undefined
       if (nestedAggFields && nestedAggFields.missingFields) {
-        let missingFieldResult = []
+        missingFieldResult = []
         nestedAggFields.missingFields.forEach((element) => {
           missingFieldResult.push({
               field: element,
@@ -447,7 +447,7 @@ export const textAggregation = async (
       }
       let termsFieldResult = undefined
       if (nestedAggFields && nestedAggFields.termsFields) {
-        let termsFieldResult = []
+        termsFieldResult = []
         nestedAggFields.termsFields.forEach((element) => {
           let tempResult = {}
           tempResult.field = element
@@ -467,7 +467,6 @@ export const textAggregation = async (
         }
         termsFieldResult.push(tempResult)
         });
-        console.log(termsFieldResult)
       }
 
       finalResults.push({

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -390,7 +390,8 @@ export const textAggregation = async (
     nestedAggQuery.aggs = {};
     if (nestedAggFields.termsFields) {
       nestedAggFields.termsFields.forEach((element) => {
-        nestedAggQuery.aggs[element] = {
+        const variableName = `${element}Terms`;
+        nestedAggQuery.aggs[variableName] = {
           terms: {
             field: element,
           },
@@ -399,7 +400,8 @@ export const textAggregation = async (
     }
     if (nestedAggFields.missingFields) {
       nestedAggFields.missingFields.forEach((element) => {
-        nestedAggQuery.aggs[element] = {
+        const variableName = `${element}Missing`;
+        nestedAggQuery.aggs[variableName] = {
           missing: {
             field: element,
           },
@@ -438,9 +440,10 @@ export const textAggregation = async (
       if (nestedAggFields && nestedAggFields.missingFields) {
         missingFieldResult = []
         nestedAggFields.missingFields.forEach((element) => {
+          const variableName = `${element}Missing`;
           missingFieldResult.push({
               field: element,
-              count: item[element].doc_count,
+              count: item[variableName].doc_count,
             },
           );
         });
@@ -452,8 +455,9 @@ export const textAggregation = async (
           let tempResult = {}
           tempResult.field = element
           tempResult.terms = []
-          if (item[element].buckets && item[element].buckets.length > 0) {
-            item[element].buckets.forEach((itemElement) => {
+          const variableName = `${element}Terms`;
+          if (item[variableName].buckets && item[variableName].buckets.length > 0) {
+            item[variableName].buckets.forEach((itemElement) => {
               tempResult.terms.push({
               key: itemElement.key,
               count: itemElement.doc_count,
@@ -469,6 +473,8 @@ export const textAggregation = async (
         });
       }
 
+      console.log(JSON.stringify(missingFieldResult))
+      console.log(JSON.stringify(termsFieldResult))
       finalResults.push({
         key: item.key[field],
         count: item.doc_count,

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -434,8 +434,9 @@ export const textAggregation = async (
     resultSize = 0;
         
     result.aggregations[aggsName].buckets.forEach((item) => {
-      let missingFieldResult = []
+      let missingFieldResult = undefined
       if (nestedAggFields && nestedAggFields.missingFields) {
+        let missingFieldResult = []
         nestedAggFields.missingFields.forEach((element) => {
           missingFieldResult.push({
               field: element,
@@ -444,8 +445,9 @@ export const textAggregation = async (
           );
         });
       }
-      let termsFieldResult = []
+      let termsFieldResult = undefined
       if (nestedAggFields && nestedAggFields.termsFields) {
+        let termsFieldResult = []
         nestedAggFields.termsFields.forEach((element) => {
           let tempResult = {}
           tempResult.field = element
@@ -471,8 +473,8 @@ export const textAggregation = async (
       finalResults.push({
         key: item.key[field],
         count: item.doc_count,
-        missingFields: missingFieldResult,
-        termsFields: termsFieldResult,
+        ...(missingFieldResult && {missingFields: missingFieldResult}),
+        ...(termsFieldResult && {termsFields: termsFieldResult}),
       });
       resultSize += 1;
     });

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -473,8 +473,6 @@ export const textAggregation = async (
         });
       }
 
-      console.log(JSON.stringify(missingFieldResult))
-      console.log(JSON.stringify(termsFieldResult))
       finalResults.push({
         key: item.key[field],
         count: item.doc_count,

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -438,7 +438,7 @@ export const textAggregation = async (
       if (nestedAggFields.missingFields) {
         nestedAggFields.missingFields.forEach((element) => {
           missingFieldResult.push({
-              key: element,
+              field: element,
               count: item[element].doc_count,
             },
           );
@@ -447,22 +447,25 @@ export const textAggregation = async (
       let termsFieldResult = []
       if (nestedAggFields.termsFields) {
         nestedAggFields.termsFields.forEach((element) => {
-          termsFieldResult[element] = []
-          console.log(element)
-          if (item.element) {
-          item.element.forEach((itemElement) => {
-            termsFieldResult[element].push({
-              key: itemElement.buckets.key,
-              count: itemElement.buckets.doc_count,
+          let tempResult = {}
+          tempResult.field = element
+          tempResult.terms = []
+          if (item[element].buckets && item[element].buckets.length > 0) {
+            item[element].buckets.forEach((itemElement) => {
+              tempResult.terms.push({
+              key: itemElement.key,
+              count: itemElement.doc_count,
             })
           })
         } else {
-          termsFieldResult[element].push({
+          tempResult.terms.push({
             key: null,
             count: 0
           })
         }
+        termsFieldResult.push(tempResult)
         });
+        console.log(termsFieldResult)
       }
 
       finalResults.push({

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -400,9 +400,9 @@ class ES {
     esType,
     filter,
     field,
-    nestedAggFields,
     filterSelf,
     defaultAuthFilter,
+    nestedAggFields,
   }) {
     return esAggregator.textAggregation(
       {
@@ -413,9 +413,9 @@ class ES {
       {
         filter,
         field,
-        nestedAggFields,
         filterSelf,
         defaultAuthFilter,
+        nestedAggFields,
       },
     );
   }

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -400,6 +400,7 @@ class ES {
     esType,
     filter,
     field,
+    nestedAggFields,
     filterSelf,
     defaultAuthFilter,
   }) {
@@ -412,6 +413,7 @@ class ES {
       {
         filter,
         field,
+        nestedAggFields,
         filterSelf,
         defaultAuthFilter,
       },

--- a/src/server/middlewares/tierAccessMiddleware/index.js
+++ b/src/server/middlewares/tierAccessMiddleware/index.js
@@ -105,7 +105,7 @@ const tierAccessResolver = (
 };
 
 /**
- * This resolver middleware is appended after aggreagtion resolvers,
+ * This resolver middleware is appended after aggregation resolvers,
  * it hide number that is less than allowed visible number for regular tier access
  * @param {bool} isGettingTotalCount
  */
@@ -119,7 +119,7 @@ const hideNumberResolver = isGettingTotalCount => async (resolve, root, args, co
   }
 
   const encryptedResult = result.map((item) => {
-    if (isWhitelisted(item.key)) { // we don't excrypt whitelisted results
+    if (isWhitelisted(item.key)) { // we don't encrypt whitelisted results
       return item;
     }
     if (item.count < config.tierAccessLimit) {

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -124,9 +124,9 @@ const textHistogramResolver = async (parent, args, context) => {
     esType,
     filter,
     field,
-    nestedAggFields,
     filterSelf,
     defaultAuthFilter,
+    nestedAggFields,
   });
   return resultPromise;
 };

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -43,7 +43,7 @@ const typeQueryResolver = (esInstance, esIndex, esType) => (parent, args, contex
  */
 const typeAggsQueryResolver = (esInstance, esIndex, esType) => (parent, args) => {
   const {
-    filter, filterSelf, needEncryptAgg, accessibility,
+    filter, filterSelf, nestedAggFields, needEncryptAgg, accessibility,
   } = args;
   log.debug('[resolver.typeAggsQueryResolver] args', args);
   return {
@@ -52,6 +52,7 @@ const typeAggsQueryResolver = (esInstance, esIndex, esType) => (parent, args) =>
     esInstance,
     esIndex,
     esType,
+    nestedAggFields,
     needEncryptAgg,
     accessibility,
   };
@@ -113,8 +114,9 @@ const textHistogramResolver = async (parent, args, context) => {
   log.debug('[resolver.textHistogramResolver] args', args);
   const {
     esInstance, esIndex, esType,
-    filter, field, filterSelf, accessibility,
+    filter, field, nestedAggFields, filterSelf, accessibility,
   } = parent;
+  log.debug('[resolver.textHistogramResolver] parent', parent);
   const { authHelper } = context;
   const defaultAuthFilter = await authHelper.getDefaultFilter(accessibility);
   const resultPromise = esInstance.textAggregation({
@@ -122,6 +124,7 @@ const textHistogramResolver = async (parent, args, context) => {
     esType,
     filter,
     field,
+    nestedAggFields,
     filterSelf,
     defaultAuthFilter,
   });

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -142,21 +142,35 @@ export const buildSchemaString = (esConfig, esInstance) => {
 
   const textHistogramSchema = `
     type ${EnumAggsHistogramName.HISTOGRAM_FOR_STRING} {
-      histogram: [BucketsForString]
+      histogram: [BucketsForNestedStringAgg]
     }
   `;
 
   const textHistogramBucketSchema = `
-    type BucketsForString {
+    type BucketsForNestedStringAgg {
       key: String
       count: Int
-      missingFields: [BucketsForNestedAggFields]
-      termsFields: [BucketsForNestedAggFields]
+      missingFields: [BucketsForNestedMissingFields]
+      termsFields: [BucketsForNestedTermsFields]
     }
   `;
 
-  const nestedAggFieldsBucketSchema = `
-    type BucketsForNestedAggFields {
+  const nestedMissingFieldsBucketSchema = `
+    type BucketsForNestedMissingFields {
+      field: String
+      count: Int
+    }
+  `;
+
+  const nestedTermsFieldsBucketSchema = `
+    type BucketsForNestedTermsFields {
+      field: String
+      terms: [BucketsForString]
+    }
+  `;
+
+  const stringBucketSchema = `
+    type BucketsForString {
       key: String
       count: Int
     }
@@ -197,7 +211,9 @@ export const buildSchemaString = (esConfig, esInstance) => {
   ${textHistogramSchema}
   ${numberHistogramSchema}
   ${textHistogramBucketSchema}
-  ${nestedAggFieldsBucketSchema}
+  ${nestedMissingFieldsBucketSchema}
+  ${nestedTermsFieldsBucketSchema}
+  ${stringBucketSchema}
   ${numberHistogramBucketSchema}
   ${mappingSchema}
 `;

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -108,6 +108,7 @@ export const getAggregationSchema = esConfig => `
       ${esConfig.indices.map(cfg => `${cfg.type} (
         filter: JSON, 
         filterSelf: Boolean=true, 
+        nestedAggFields: JSON
         """Only used when it's regular level data commons, if set, returns aggregation data within given accessibility"""
         accessibility: Accessibility=all
       ): ${firstLetterUpperCase(cfg.type)}Aggregation`).join('\n')}
@@ -149,6 +150,15 @@ export const buildSchemaString = (esConfig, esInstance) => {
     type BucketsForString {
       key: String
       count: Int
+      missingFields: [BucketsForNestedAggFields]
+      termsFields: [BucketsForNestedAggFields]
+    }
+  `;
+
+  const nestedAggFieldsBucketSchema = `
+    type BucketsForNestedAggFields {
+      key: String
+      count: Int
     }
   `;
 
@@ -187,6 +197,7 @@ export const buildSchemaString = (esConfig, esInstance) => {
   ${textHistogramSchema}
   ${numberHistogramSchema}
   ${textHistogramBucketSchema}
+  ${nestedAggFieldsBucketSchema}
   ${numberHistogramBucketSchema}
   ${mappingSchema}
 `;

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -108,7 +108,7 @@ export const getAggregationSchema = esConfig => `
       ${esConfig.indices.map(cfg => `${cfg.type} (
         filter: JSON, 
         filterSelf: Boolean=true, 
-        nestedAggFields: JSON
+        nestedAggFields: JSON,
         """Only used when it's regular level data commons, if set, returns aggregation data within given accessibility"""
         accessibility: Accessibility=all
       ): ${firstLetterUpperCase(cfg.type)}Aggregation`).join('\n')}


### PR DESCRIPTION
Support nested aggregation queries
Example query:
```
query ($filter: JSON, $nestedAggFields: JSON) {      
      _aggregation {
        subject (filter: $filter, nestedAggFields: $nestedAggFields) {
           file_type {
             histogram {
                key
                count
                missingFields {
                    field
                    count
                }
                termsFields {
                    field
                    terms {
                       key
                      count
                    }
                }
           }
        }
      }
   }
}
```
with this kind of JSON `nestedAggFields` variable
```
"nestedAggFields": {
      "missingFields": [
	    "someNonExistingField",
	    "gender"
        ],
       "termsFields": [
	    "project",
	     "someNonExistingField"
	]
}
```

Example result:
```
{
  "data": {
    "_aggregation": {
      "subject": {
        "file_type": {
          "histogram": [
            {
              "key": "Unaligned Reads",
              "count": 2,
              "missingFields": [
                {
                  "field": "someNonExistingField",
                  "count": 2
                },
                {
                  "field": "gender",
                  "count": 0
                }
              ],
              "termsFields": [
                {
                  "field": "project",
                  "terms": [
                    {
                      "key": "DEV-test",
                      "count": 2
                    }
                  ]
                },
                {
                  "field": "someNonExistingField",
                  "terms": [
                    {
                      "key": null,
                      "count": 0
                    }
                  ]
                }
              ]
            },
            {
              "key": "1Gs Ribosomes",
              "count": 1,
              "missingFields": [
                {
                  "field": "someNonExistingField",
                  "count": 1
                },
                {
                  "field": "gender",
                  "count": 0
                }
              ],
              "termsFields": [
                {
                  "field": "project",
                  "terms": [
                    {
                      "key": "DEV-test",
                      "count": 1
                    }
                  ]
                },
                {
                  "field": "someNonExistingField",
                  "terms": [
                    {
                      "key": null,
                      "count": 0
                    }
                  ]
                }
              ]
            }
          ]
        }
      }
    }
  }
}
```

### New Features
- Guppy now support this kind of nested aggregation queries
- Guppy also has a wrapper query function `queryGuppyForNestedAgg` that helps to build this kind of GQL queries

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

