### PR TITLE
feat/support `is not` op for filter

### DIFF
--- a/src/server/es/filter.js
+++ b/src/server/es/filter.js
@@ -16,7 +16,6 @@ const getNumericTextType = (
   return numericTextType;
 };
 
-// FIXME: support "is not"
 const getFilterItemForString = (op, field, value) => {
   switch (op) {
     case '=':
@@ -32,6 +31,18 @@ const getFilterItemForString = (op, field, value) => {
       return {
         terms: {
           [field]: value,
+        },
+      };
+    case '!=':
+      return {
+        bool: {
+          must_not: [
+            {
+              term: {
+                [field]: value,
+              },
+            },
+          ],
         },
       };
     default:
@@ -72,6 +83,24 @@ const getFilterItemForNumbers = (op, field, value) => {
     return {
       terms: {
         [field]: value,
+      },
+    };
+  }
+  if (op === '!=') {
+    return {
+      bool: {
+        should: [
+          {
+            range: {
+              [field]: { gt: value },
+            },
+          },
+          {
+            range: {
+              [field]: { lt: value },
+            },
+          },
+        ],
       },
     };
   }


### PR DESCRIPTION
Guppy need to support `!=` op in filter in order to make NIAID HIV app work with Guppy

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Support `!=` (is not) op for filter

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

