### PR TITLE
filters for missing fields

### DIFF
--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -74,8 +74,14 @@ const mockResourcePath = () => {
   const queryResourceWithFilter1 = {
     size: 0,
     query: {
-      term: {
-        gen3_resource_path: 'internal-project-1',
+      bool: {
+        must: [
+          {
+            term: {
+              gen3_resource_path: 'internal-project-1',
+            },
+          },
+        ],
       },
     },
     aggs: {
@@ -122,8 +128,14 @@ const mockResourcePath = () => {
   const queryResourceWithFilter2 = {
     size: 0,
     query: {
-      term: {
-        gen3_resource_path: 'external-project-1',
+      bool: {
+        must: [
+          {
+            term: {
+              gen3_resource_path: 'external-project-1',
+            },
+          },
+        ],
       },
     },
     aggs: {

--- a/src/server/__mocks__/mockESData/mockNumericAggsGlobalStats.js
+++ b/src/server/__mocks__/mockESData/mockNumericAggsGlobalStats.js
@@ -29,8 +29,14 @@ const mockNumericAggsGlobalStats = () => {
   const fileCountGlobalStatsAggsQuery1 = {
     size: 0,
     query: {
-      term: {
-        gender: 'female',
+      bool: {
+        must: [
+          {
+            term: {
+              gender: 'female',
+            },
+          },
+        ],
       },
     },
     aggs: {
@@ -102,8 +108,14 @@ const mockNumericAggsGlobalStats = () => {
   const fileCountGlobalStatsAggsQuery3 = {
     size: 0,
     query: {
-      terms: {
-        gen3_resource_path: ['internal-project-1', 'internal-project-2'],
+      bool: {
+        must: [
+          {
+            terms: {
+              gen3_resource_path: ['internal-project-1', 'internal-project-2'],
+            },
+          },
+        ],
       },
     },
     aggs: {

--- a/src/server/__mocks__/mockESData/mockNumericHistogramFixBinCount.js
+++ b/src/server/__mocks__/mockESData/mockNumericHistogramFixBinCount.js
@@ -114,8 +114,14 @@ const mockHistogramFixBinCount = () => {
       bool: {
         must: [
           {
-            term: {
-              gender: 'female',
+            bool: {
+              must: [
+                {
+                  term: {
+                    gender: 'female',
+                  },
+                },
+              ],
             },
           },
           [
@@ -333,10 +339,13 @@ const mockHistogramFixBinCount = () => {
       bool: {
         must: [
           {
-            terms: {
-              gen3_resource_path: [
-                'internal-project-1',
-                'internal-project-2',
+            bool: {
+              must: [
+                {
+                  terms: {
+                    gen3_resource_path: ['internal-project-1', 'internal-project-2'],
+                  },
+                },
               ],
             },
           },

--- a/src/server/__mocks__/mockESData/mockNumericHistogramFixWidth.js
+++ b/src/server/__mocks__/mockESData/mockNumericHistogramFixWidth.js
@@ -83,8 +83,14 @@ const mockHistogramFixWidth = () => {
   const fileCountHistogramFixWidthQuery1 = {
     size: 0,
     query: {
-      term: {
-        gender: 'female',
+      bool: {
+        must: [
+          {
+            term: {
+              gender: 'female',
+            },
+          },
+        ],
       },
     },
     aggs: {
@@ -232,10 +238,13 @@ const mockHistogramFixWidth = () => {
   const fileCountHistogramFixWidthQuery3 = {
     size: 0,
     query: {
-      terms: {
-        gen3_resource_path: [
-          'internal-project-1',
-          'internal-project-2',
+      bool: {
+        must: [
+          {
+            terms: {
+              gen3_resource_path: ['internal-project-1', 'internal-project-2'],
+            },
+          },
         ],
       },
     },

--- a/src/server/__mocks__/mockESData/mockTextAggs.js
+++ b/src/server/__mocks__/mockESData/mockTextAggs.js
@@ -63,10 +63,16 @@ const mockTextAggs = () => {
   const genderAggsQuery2 = {
     size: 0,
     query: {
-      terms: {
-        gender: [
-          'female',
-          'male',
+      bool: {
+        must: [
+          {
+            terms: {
+              gender: [
+                'female',
+                'male',
+              ],
+            },
+          },
         ],
       },
     },
@@ -123,10 +129,16 @@ const mockTextAggs = () => {
   const genderAggsQuery3 = {
     size: 0,
     query: {
-      terms: {
-        gen3_resource_path: [
-          'internal-project-1',
-          'internal-project-2',
+      bool: {
+        must: [
+          {
+            terms: {
+              gen3_resource_path: [
+                'internal-project-1',
+                'internal-project-2',
+              ],
+            },
+          },
         ],
       },
     },

--- a/src/server/es/__tests__/filter.test.js
+++ b/src/server/es/__tests__/filter.test.js
@@ -36,7 +36,17 @@ describe('Transfer GraphQL filter to ES filter, filter unit', () => {
     const resultESFilter1 = getFilterObj(esInstance, esIndex, esType, gqlFilter1);
     const resultESFilter2 = getFilterObj(esInstance, esIndex, esType, gqlFilter2);
     const resultESFilter3 = getFilterObj(esInstance, esIndex, esType, gqlFilter3);
-    const expectedESFilter = { term: { gender: 'female' } };
+    const expectedESFilter = {
+      bool: {
+        must: [
+          {
+            term: {
+              gender: 'female',
+            },
+          },
+        ],
+      },
+    };
     expect(resultESFilter1).toEqual(expectedESFilter);
     expect(resultESFilter2).toEqual(expectedESFilter);
     expect(resultESFilter3).toEqual(expectedESFilter);
@@ -49,7 +59,17 @@ describe('Transfer GraphQL filter to ES filter, filter unit', () => {
     const gqlFilter2 = { IN: { gender: ['female', 'unknown'] } };
     const resultESFilter1 = getFilterObj(esInstance, esIndex, esType, gqlFilter1);
     const resultESFilter2 = getFilterObj(esInstance, esIndex, esType, gqlFilter2);
-    const expectedESFilter = { terms: { gender: ['female', 'unknown'] } };
+    const expectedESFilter = {
+      bool: {
+        must: [
+          {
+            terms: {
+              gender: ['female', 'unknown'],
+            },
+          },
+        ],
+      },
+    };
     expect(resultESFilter1).toEqual(expectedESFilter);
     expect(resultESFilter2).toEqual(expectedESFilter);
   });
@@ -63,7 +83,17 @@ describe('Transfer GraphQL filter to ES filter, filter unit', () => {
     const resultESFilter1 = getFilterObj(esInstance, esIndex, esType, gqlFilter1);
     const resultESFilter2 = getFilterObj(esInstance, esIndex, esType, gqlFilter2);
     const resultESFilter3 = getFilterObj(esInstance, esIndex, esType, gqlFilter3);
-    const expectedESFilter = { term: { file_count: 10 } };
+    const expectedESFilter = {
+      bool: {
+        must: [
+          {
+            term: {
+              file_count: 10,
+            },
+          },
+        ],
+      },
+    };
     expect(resultESFilter1).toEqual(expectedESFilter);
     expect(resultESFilter2).toEqual(expectedESFilter);
     expect(resultESFilter3).toEqual(expectedESFilter);
@@ -76,7 +106,17 @@ describe('Transfer GraphQL filter to ES filter, filter unit', () => {
     const gqlFilter2 = { IN: { file_count: [10, 20] } };
     const resultESFilter1 = getFilterObj(esInstance, esIndex, esType, gqlFilter1);
     const resultESFilter2 = getFilterObj(esInstance, esIndex, esType, gqlFilter2);
-    const expectedESFilter = { terms: { file_count: [10, 20] } };
+    const expectedESFilter = {
+      bool: {
+        must: [
+          {
+            terms: {
+              file_count: [10, 20],
+            },
+          },
+        ],
+      },
+    };
     expect(resultESFilter1).toEqual(expectedESFilter);
     expect(resultESFilter2).toEqual(expectedESFilter);
   });
@@ -185,8 +225,28 @@ describe('Transfer GraphQL filter to ES filter, combined filter', () => {
     const expectedESFilter = {
       bool: {
         must: [
-          { term: { gender: 'female' } },
-          { term: { file_count: 10 } },
+          {
+            bool: {
+              must: [
+                {
+                  term: {
+                    gender: 'female',
+                  },
+                },
+              ],
+            },
+          },
+          {
+            bool: {
+              must: [
+                {
+                  term: {
+                    file_count: 10,
+                  },
+                },
+              ],
+            },
+          },
         ],
       },
     };
@@ -213,8 +273,28 @@ describe('Transfer GraphQL filter to ES filter, combined filter', () => {
     const expectedESFilter = {
       bool: {
         should: [
-          { term: { gender: 'female' } },
-          { term: { file_count: 10 } },
+          {
+            bool: {
+              must: [
+                {
+                  term: {
+                    gender: 'female',
+                  },
+                },
+              ],
+            },
+          },
+          {
+            bool: {
+              must: [
+                {
+                  term: {
+                    file_count: 10,
+                  },
+                },
+              ],
+            },
+          },
         ],
       },
     };
@@ -257,8 +337,28 @@ describe('Transfer GraphQL filter to ES filter, combined filter', () => {
           {
             bool: {
               must: [
-                { term: { gender: 'female' } },
-                { term: { file_count: 10 } },
+                {
+                  bool: {
+                    must: [
+                      {
+                        term: {
+                          gender: 'female',
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  bool: {
+                    must: [
+                      {
+                        term: {
+                          file_count: 10,
+                        },
+                      },
+                    ],
+                  },
+                },
               ],
             },
           },
@@ -268,16 +368,56 @@ describe('Transfer GraphQL filter to ES filter, combined filter', () => {
                 {
                   bool: {
                     must: [
-                      { term: { gender: 'male' } },
-                      { term: { file_count: 20 } },
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                gender: 'male',
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                file_count: 20,
+                              },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
                 {
                   bool: {
                     must: [
-                      { term: { gender: 'unknown' } },
-                      { term: { file_count: 30 } },
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                gender: 'unknown',
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                file_count: 30,
+                              },
+                            },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },
@@ -311,7 +451,17 @@ describe('Transfer GraphQL filter to ES filter, with other params', () => {
     const expectedESFilter = {
       bool: {
         must: [
-          { term: { file_count: 10 } },
+          {
+            bool: {
+              must: [
+                {
+                  term: {
+                    file_count: 10,
+                  },
+                },
+              ],
+            },
+          },
         ],
       },
     };
@@ -322,7 +472,17 @@ describe('Transfer GraphQL filter to ES filter, with other params', () => {
     await esInstance.initialize();
     const gqlFilter = { eq: { gender: 'female' } };
     const resultESFilter = getFilterObj(esInstance, esIndex, esType, gqlFilter, 'file_count', false);
-    const expectedESFilter = { term: { gender: 'female' } };
+    const expectedESFilter = {
+      bool: {
+        must: [
+          {
+            term: {
+              gender: 'female',
+            },
+          },
+        ],
+      },
+    };
     expect(resultESFilter).toEqual(expectedESFilter);
   });
 
@@ -331,7 +491,17 @@ describe('Transfer GraphQL filter to ES filter, with other params', () => {
     const defaultAuthFilter = { '=': { gen3_resource_path: 'internal' } };
     const gqlFilter = { eq: { gender: 'female' } };
     const resultESFilter = getFilterObj(esInstance, esIndex, esType, gqlFilter, 'gender', false, defaultAuthFilter);
-    const expectedESFilter = { term: { gen3_resource_path: 'internal' } };
+    const expectedESFilter = {
+      bool: {
+        must: [
+          {
+            term: {
+              gen3_resource_path: 'internal',
+            },
+          },
+        ],
+      },
+    };
     expect(resultESFilter).toEqual(expectedESFilter);
   });
 });

--- a/src/server/es/filter.js
+++ b/src/server/es/filter.js
@@ -22,6 +22,7 @@ const getFilterItemForString = (op, field, value) => {
     case '=':
     case 'eq':
     case 'EQ':
+      // special case when missingDataAlias is in using
       if (config.esConfig.aggregationIncludeMissingData
         && value === config.esConfig.missingDataAlias) {
         return {
@@ -49,6 +50,8 @@ const getFilterItemForString = (op, field, value) => {
       };
     case 'in':
     case 'IN':
+      // if using missingDataAlias, we need to remove the missingDataAlias from filter values
+      // and then add a must_not exists bool func to compensate missingDataAlias
       if (config.esConfig.aggregationIncludeMissingData
           && value.includes(config.esConfig.missingDataAlias)) {
         const newValue = value.filter(element => element !== config.esConfig.missingDataAlias);
@@ -81,6 +84,7 @@ const getFilterItemForString = (op, field, value) => {
           },
         };
       }
+      // if not using missingDataAlias or filter doesn't contain missingDataAlias
       return {
         bool: {
           must: [


### PR DESCRIPTION
By default Guppy's elasticsearch aggregation result includes missing data (`aggs_include_missing_data=true`) and missing data were aliased into keyword `no data` (the default `missing_data_alias` value). 
But in this case, selecting `no data` as a facet in data explorer will zeros out the result. Since the `no data` is just a fake alias created by guppy, not an value from an actual es field.
This PR changes the logic of parsing the GQLFilter into ES filter and takes `aggs_include_missing_data` into consideration. If `aggs_include_missing_data` is in using, it will translate any GQLFilter that contains `missing_data_alias` into appropriate ES query 

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- Correctly translate GQLFilter if a missing value from a filed has been selected into the filter

### Improvements


### Dependency updates


### Deployment changes

