### PR TITLE
Fix/nested agg size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/src/server/__mocks__/mockESData/mockNestedAggs.js
+++ b/src/server/__mocks__/mockESData/mockNestedAggs.js
@@ -91,11 +91,13 @@ const mockNestedAggs = () => {
           genderTerms: {
             terms: {
               field: 'gender',
+              size: 10000,
             },
           },
           someNonExistingFieldTerms: {
             terms: {
               field: 'someNonExistingField',
+              size: 10000,
             },
           },
         },
@@ -199,11 +201,13 @@ const mockNestedAggs = () => {
           genderTerms: {
             terms: {
               field: 'gender',
+              size: 10000,
             },
           },
           someNonExistingFieldTerms: {
             terms: {
               field: 'someNonExistingField',
+              size: 10000,
             },
           },
         },

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -7,6 +7,8 @@ import {
 } from './const';
 import config from '../config';
 
+const PAGE_SIZE = 10000;
+
 const updateAggObjectForTermsFields = (termsFields, aggsObj) => {
   const newAggsObj = { ...aggsObj };
   termsFields.forEach((element) => {
@@ -14,6 +16,7 @@ const updateAggObjectForTermsFields = (termsFields, aggsObj) => {
     newAggsObj[variableName] = {
       terms: {
         field: element,
+        size: PAGE_SIZE,
       },
     };
   });
@@ -447,8 +450,6 @@ export const numericAggregation = async (
   );
   return [result];
 };
-
-const PAGE_SIZE = 10000;
 
 /**
  * This function does aggregation for text field, and returns histogram


### PR DESCRIPTION
Add `size` field for aggregated terms queries to return more than 10 records 

### New Features


### Breaking Changes


### Bug Fixes
- Change nested terms agg default size limit

### Improvements


### Dependency updates


### Deployment changes

