### PR TITLE
Feat/project study filters phs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -102,6 +102,7 @@ class ConnectedFilter extends React.Component {
     console.log('ConnectedFilter handleFilterChange: ', JSON.parse(JSON.stringify(filterResults)));
     this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
     let mergedFilterResults = mergeFilters(userFilter, this.state.adminAppliedPreFilters);
+    console.log('ConnectedFilter mergedFilterResults: ', mergedFilterResults);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -45,7 +45,7 @@ class ConnectedFilter extends React.Component {
       this.state.accessibility,
     )
       .then((res) => {
-        this.handleReceiveNewAggsData(res.data._aggregation[this.props.guppyConfig.type]);
+        this.handleReceiveNewAggsData(res.data._aggregation[this.props.guppyConfig.type], this.state.adminAppliedPreFilters);
         this.saveInitialAggsData(res.data._aggregation[this.props.guppyConfig.type]);
       });
   }

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -23,6 +23,7 @@ class ConnectedFilter extends React.Component {
       receivedAggsData: {},
       accessibility: ENUM_ACCESSIBILITY.ALL,
       adminAppliedPreFilters: Object.assign({}, this.props.adminAppliedPreFilters),
+      filter: Object.assign({}, this.props.adminAppliedPreFilters),
     };
     this.filterGroupRef = React.createRef();
 

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -44,6 +44,7 @@ class ConnectedFilter extends React.Component {
       this.props.guppyConfig.type,
       this.state.allFields,
       this.state.accessibility,
+      this.state.filter,
     )
       .then((res) => {
         this.handleReceiveNewAggsData(res.data._aggregation[this.props.guppyConfig.type], this.state.adminAppliedPreFilters);

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -21,9 +21,13 @@ class ConnectedFilter extends React.Component {
       initialAggsData: {},
       receivedAggsData: {},
       accessibility: ENUM_ACCESSIBILITY.ALL,
+      adminAppliedPreFilters: Object.assign({}, this.props.adminAppliedPreFilters),
     };
     this.filterGroupRef = React.createRef();
+
     this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
+    Object.freeze(this.adminObjectReadOnly);
+    this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
   }
 
   componentDidMount() {
@@ -61,7 +65,7 @@ class ConnectedFilter extends React.Component {
         key={index}
         sections={
           getFilterSections(fields, fieldMapping, processedTabsOptions, 
-            this.state.initialAggsData, this.props.adminAppliedPreFilters)
+            this.state.initialAggsData, this.state.adminAppliedPreFilters)
         }
         tierAccessLimit={this.props.tierAccessLimit}
       />

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -59,7 +59,8 @@ class ConnectedFilter extends React.Component {
       <FilterList
         key={index}
         sections={
-          getFilterSections(fields, fieldMapping, processedTabsOptions, this.state.initialAggsData)
+          getFilterSections(fields, fieldMapping, processedTabsOptions, 
+            this.state.initialAggsData, this.props.adminAppliedPreFilters)
         }
         tierAccessLimit={this.props.tierAccessLimit}
       />
@@ -161,6 +162,7 @@ ConnectedFilter.propTypes = {
   tierAccessLimit: PropTypes.number,
   onProcessFilterAggsData: PropTypes.func,
   onUpdateAccessLevel: PropTypes.func,
+  adminAppliedPreFilters: PropTypes.object,
 };
 
 ConnectedFilter.defaultProps = {
@@ -172,6 +174,7 @@ ConnectedFilter.defaultProps = {
   tierAccessLimit: undefined,
   onProcessFilterAggsData: data => (data),
   onUpdateAccessLevel: () => {},
+  adminAppliedPreFilters: {},
 };
 
 export default ConnectedFilter;

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -12,6 +12,7 @@ import {
   askGuppyForAggregationData,
   getAllFieldsFromFilterConfigs,
 } from '../Utils/queries';
+import { mergeFilters } from '../Utils/queries';
 
 class ConnectedFilter extends React.Component {
   constructor(props) {
@@ -99,22 +100,24 @@ class ConnectedFilter extends React.Component {
    */
   handleFilterChange(filterResults) {
     console.log('ConnectedFilter handleFilterChange: ', JSON.parse(JSON.stringify(filterResults)));
+    this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
+    let mergedFilterResults = mergeFilters(userFilter, this.state.adminAppliedPreFilters);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,
       this.state.allFields,
-      filterResults,
+      mergedFilterResults,
       this.state.accessibility,
     )
       .then((res) => {
         this.handleReceiveNewAggsData(
           res.data._aggregation[this.props.guppyConfig.type],
-          filterResults,
+          mergedFilterResults,
         );
       });
 
     if (this.props.onFilterChange) {
-      this.props.onFilterChange(filterResults, this.state.accessibility);
+      this.props.onFilterChange(mergedFilterResults, this.state.accessibility);
     }
   }
 

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -102,7 +102,7 @@ class ConnectedFilter extends React.Component {
    * @param {object} filterResults
    */
   handleFilterChange(filterResults) {
-    this.state.adminAppliedPreFilters = JSON.parse(this.adminPreFiltersFrozen);
+    this.setState({ adminAppliedPreFilters: JSON.parse(this.adminPreFiltersFrozen) });
     const mergedFilterResults = mergeFilters(filterResults, this.state.adminAppliedPreFilters);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -23,7 +23,7 @@ class ConnectedFilter extends React.Component {
       accessibility: ENUM_ACCESSIBILITY.ALL,
     };
     this.filterGroupRef = React.createRef();
-    Object.freeze(this.props.adminAppliedPreFilters);
+    this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
   }
 
   componentDidMount() {

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -12,7 +12,7 @@ import {
   askGuppyForAggregationData,
   getAllFieldsFromFilterConfigs,
 } from '../Utils/queries';
-import { mergeFilters } from '../Utils/queries';
+import { mergeFilters } from '../Utils/filters';
 
 class ConnectedFilter extends React.Component {
   constructor(props) {

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -101,7 +101,7 @@ class ConnectedFilter extends React.Component {
   handleFilterChange(filterResults) {
     console.log('ConnectedFilter handleFilterChange: ', JSON.parse(JSON.stringify(filterResults)));
     this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
-    let mergedFilterResults = mergeFilters(userFilter, this.state.adminAppliedPreFilters);
+    let mergedFilterResults = mergeFilters(filterResults, this.state.adminAppliedPreFilters);
     console.log('ConnectedFilter mergedFilterResults: ', mergedFilterResults);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -37,7 +37,6 @@ class ConnectedFilter extends React.Component {
       this.props.onUpdateAccessLevel(this.state.accessibility);
     }
     if (this.props.onFilterChange) {
-      console.log('componentDidMount has ', this.state.adminAppliedPreFilters);
       this.props.onFilterChange(this.state.adminAppliedPreFilters, this.state.accessibility);
     }
     askGuppyAboutAllFieldsAndOptions(
@@ -102,10 +101,8 @@ class ConnectedFilter extends React.Component {
    * @param {object} filterResults
    */
   handleFilterChange(filterResults) {
-    console.log('ConnectedFilter handleFilterChange: ', JSON.parse(JSON.stringify(filterResults)));
     this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
     let mergedFilterResults = mergeFilters(filterResults, this.state.adminAppliedPreFilters);
-    console.log('ConnectedFilter mergedFilterResults: ', mergedFilterResults);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -27,10 +27,7 @@ class ConnectedFilter extends React.Component {
       filter: Object.assign({}, this.props.adminAppliedPreFilters),
     };
     this.filterGroupRef = React.createRef();
-
-    this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
-    Object.freeze(this.adminObjectReadOnly);
-    this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
+    this.adminPreFiltersFrozen = JSON.stringify(this.props.adminAppliedPreFilters).slice();
   }
 
   componentDidMount() {
@@ -105,7 +102,7 @@ class ConnectedFilter extends React.Component {
    * @param {object} filterResults
    */
   handleFilterChange(filterResults) {
-    this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
+    this.state.adminAppliedPreFilters = JSON.parse(this.adminPreFiltersFrozen);
     const mergedFilterResults = mergeFilters(filterResults, this.state.adminAppliedPreFilters);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -93,7 +93,7 @@ class ConnectedFilter extends React.Component {
    * @param {object} filterResults
    */
   handleFilterChange(filterResults) {
-    console.log('ConnectedFilter handleFilterChange: ', filterResults);
+    console.log('ConnectedFilter handleFilterChange: ', JSON.parse(JSON.stringify(filterResults)));
     askGuppyForAggregationData(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -36,6 +36,7 @@ class ConnectedFilter extends React.Component {
       this.props.onUpdateAccessLevel(this.state.accessibility);
     }
     if (this.props.onFilterChange) {
+      console.log('componentDidMount has ', this.state.adminAppliedPreFilters);
       this.props.onFilterChange(this.state.adminAppliedPreFilters, this.state.accessibility);
     }
     askGuppyAboutAllFieldsAndOptions(

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -1,3 +1,4 @@
+/* eslint react/forbid-prop-types: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import FilterGroup from '@gen3/ui-component/dist/components/filters/FilterGroup';
@@ -47,7 +48,10 @@ class ConnectedFilter extends React.Component {
       this.state.filter,
     )
       .then((res) => {
-        this.handleReceiveNewAggsData(res.data._aggregation[this.props.guppyConfig.type], this.state.adminAppliedPreFilters);
+        this.handleReceiveNewAggsData(
+          res.data._aggregation[this.props.guppyConfig.type],
+          this.state.adminAppliedPreFilters,
+        );
         this.saveInitialAggsData(res.data._aggregation[this.props.guppyConfig.type]);
       });
   }
@@ -67,7 +71,7 @@ class ConnectedFilter extends React.Component {
       <FilterList
         key={index}
         sections={
-          getFilterSections(fields, fieldMapping, processedTabsOptions, 
+          getFilterSections(fields, fieldMapping, processedTabsOptions,
             this.state.initialAggsData, this.state.adminAppliedPreFilters)
         }
         tierAccessLimit={this.props.tierAccessLimit}
@@ -102,7 +106,7 @@ class ConnectedFilter extends React.Component {
    */
   handleFilterChange(filterResults) {
     this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
-    let mergedFilterResults = mergeFilters(filterResults, this.state.adminAppliedPreFilters);
+    const mergedFilterResults = mergeFilters(filterResults, this.state.adminAppliedPreFilters);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -36,7 +36,7 @@ class ConnectedFilter extends React.Component {
       this.props.onUpdateAccessLevel(this.state.accessibility);
     }
     if (this.props.onFilterChange) {
-      this.props.onFilterChange({}, this.state.accessibility);
+      this.props.onFilterChange(this.state.adminAppliedPreFilters, this.state.accessibility);
     }
     askGuppyAboutAllFieldsAndOptions(
       this.props.guppyConfig.path,

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -23,6 +23,7 @@ class ConnectedFilter extends React.Component {
       accessibility: ENUM_ACCESSIBILITY.ALL,
     };
     this.filterGroupRef = React.createRef();
+    Object.freeze(this.props.adminAppliedPreFilters);
   }
 
   componentDidMount() {

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -92,6 +92,7 @@ class ConnectedFilter extends React.Component {
    * @param {object} filterResults
    */
   handleFilterChange(filterResults) {
+    console.log('ConnectedFilter handleFilterChange: ', filterResults);
     askGuppyForAggregationData(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -43,7 +43,7 @@ const capitalizeFirstLetter = (str) => {
 
 export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabsOptions, adminAppliedPreFilters) => {
   console.log('-----------');
-  console.log('GUPPY GET FILTER SECTIONS ADMIN FILTERS ', adminAppliedPreFilters);
+  console.log('(46) GUPPY GET FILTER SECTIONS ADMIN FILTERS ', adminAppliedPreFilters);
   const sections = fields.map((field) => {
     const overrideName = fieldMapping.find(entry => (entry.field === field));
     console.log('overrideName: ', overrideName);
@@ -65,16 +65,13 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
       initialTabsOptions ? initialTabsOptions[field] : undefined,
     );
 
-    
-    
-    const rv = {
+    return {
       title: label,
       options: defaultOptions,
     };
-    console.log('rv returning ', rv);
-    return rv;
   });
   console.log('guppy utils.js line 56 sections: ', sections);
+  console.log('(74) GUPPY GET FILTER SECTIONS ADMIN FILTERS ', adminAppliedPreFilters);
 
   return sections;
 };

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -56,7 +56,6 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
       initialTabsOptions ? initialTabsOptions[field] : undefined,
     );
 
-    Object.assign(defaultOptions, admin);
     if (Object.keys(adminAppliedPreFilters).includes(field)) {
       let adminOptions = getSingleFilterOption(
         adminAppliedPreFilters,

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -42,15 +42,9 @@ const capitalizeFirstLetter = (str) => {
 };
 
 export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabsOptions, adminAppliedPreFilters) => {
-  console.log('-----------');
-  console.log('(46) GUPPY GET FILTER SECTIONS ADMIN FILTERS ', adminAppliedPreFilters);
   const sections = fields.map((field) => {
     const overrideName = fieldMapping.find(entry => (entry.field === field));
-    console.log('overrideName: ', overrideName);
     const label = overrideName ? overrideName.name : capitalizeFirstLetter(field);
-    console.log('label: ', label);
-    console.log('tabsOptions[field]', tabsOptions[field]);
-    console.log('initialTabsOptions', initialTabsOptions);
     
     let tabsOptionsFiltered = Object.assign({}, tabsOptions[field]);
     if (Object.keys(adminAppliedPreFilters).includes(field)) {
@@ -58,7 +52,6 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
         adminAppliedPreFilters[field].selectedValues.includes(x.key)
       );
     }
-    console.log('tabsOptionsFiltered: ', tabsOptionsFiltered);
 
     let defaultOptions = getSingleFilterOption(
       tabsOptionsFiltered,
@@ -70,8 +63,6 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
       options: defaultOptions,
     };
   });
-  console.log('guppy utils.js line 56 sections: ', sections);
-  console.log('(74) GUPPY GET FILTER SECTIONS ADMIN FILTERS ', adminAppliedPreFilters);
 
   return sections;
 };

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -58,10 +58,10 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
         adminAppliedPreFilters[field].selectedValues.includes(x.key)
       );
     }
-    console.log('tabOptionsFiltered: ', tabOptionsFiltered);
+    console.log('tabsOptionsFiltered: ', tabsOptionsFiltered);
 
     let defaultOptions = getSingleFilterOption(
-      tabOptionsFiltered,
+      tabsOptionsFiltered,
       initialTabsOptions ? initialTabsOptions[field] : undefined,
     );
 

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -42,19 +42,27 @@ const capitalizeFirstLetter = (str) => {
 };
 
 export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabsOptions, adminAppliedPreFilters) => {
+  console.log('-----------');
   console.log('GUPPY GET FILTER SECTIONS ADMIN FILTERS ', adminAppliedPreFilters);
   const sections = fields.map((field) => {
     const overrideName = fieldMapping.find(entry => (entry.field === field));
+    console.log('overrideName: ', overrideName);
     const label = overrideName ? overrideName.name : capitalizeFirstLetter(field);
-    return {
+    console.log('label: ', label);
+    const defaultOptions = getSingleFilterOption(
+      tabsOptions[field],
+      initialTabsOptions ? initialTabsOptions[field] : undefined,
+    );
+    console.log('defaultOptions: ', defaultOptions);
+    const rv = {
       title: label,
-      options: getSingleFilterOption(
-        tabsOptions[field],
-        initialTabsOptions ? initialTabsOptions[field] : undefined,
-      ),
+      options: defaultOptions,
     };
+    console.log('rv returning ', rv);
+    return rv;
   });
   console.log('guppy utils.js line 56 sections: ', sections);
+
   return sections;
 };
 

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -49,11 +49,23 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
     console.log('overrideName: ', overrideName);
     const label = overrideName ? overrideName.name : capitalizeFirstLetter(field);
     console.log('label: ', label);
-    const defaultOptions = getSingleFilterOption(
+    console.log('tabsOptions[field]', tabsOptions[field]);
+    console.log('initialTabsOptions', initialTabsOptions);
+    let defaultOptions = getSingleFilterOption(
       tabsOptions[field],
       initialTabsOptions ? initialTabsOptions[field] : undefined,
     );
-    console.log('defaultOptions: ', defaultOptions);
+
+    Object.assign(defaultOptions, admin);
+    if (Object.keys(adminAppliedPreFilters).includes(field)) {
+      let adminOptions = getSingleFilterOption(
+        adminAppliedPreFilters,
+        undefined
+      );
+
+      Object.assign(defaultOptions, adminOptions);
+    }
+    console.log('defaultOptions after Object.assign: ', defaultOptions);
     const rv = {
       title: label,
       options: defaultOptions,

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -41,19 +41,21 @@ const capitalizeFirstLetter = (str) => {
   return res.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 };
 
-export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabsOptions, adminAppliedPreFilters) => {
+export const getFilterSections = (
+  fields, fieldMapping, tabsOptions, initialTabsOptions, adminAppliedPreFilters,
+) => {
   const sections = fields.map((field) => {
     const overrideName = fieldMapping.find(entry => (entry.field === field));
     const label = overrideName ? overrideName.name : capitalizeFirstLetter(field);
-    
-    let tabsOptionsFiltered = Object.assign({}, tabsOptions[field]);
+
+    const tabsOptionsFiltered = Object.assign({}, tabsOptions[field]);
     if (Object.keys(adminAppliedPreFilters).includes(field)) {
-      tabsOptionsFiltered.histogram = tabsOptionsFiltered.histogram.filter(x => 
-        adminAppliedPreFilters[field].selectedValues.includes(x.key)
+      tabsOptionsFiltered.histogram = tabsOptionsFiltered.histogram.filter(
+        x => adminAppliedPreFilters[field].selectedValues.includes(x.key),
       );
     }
 
-    let defaultOptions = getSingleFilterOption(
+    const defaultOptions = getSingleFilterOption(
       tabsOptionsFiltered,
       initialTabsOptions ? initialTabsOptions[field] : undefined,
     );

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -55,7 +55,7 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
     let tabsOptionsFiltered = Object.assign({}, tabsOptions[field]);
     if (Object.keys(adminAppliedPreFilters).includes(field)) {
       tabsOptionsFiltered.histogram = tabsOptionsFiltered.histogram.filter(x => 
-        adminAppliedPreFilters[field].allowedValues.includes(x.key)
+        adminAppliedPreFilters[field].selectedValues.includes(x.key)
       );
     }
     console.log('tabsOptionsFiltered: ', tabsOptionsFiltered);

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -51,20 +51,22 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
     console.log('label: ', label);
     console.log('tabsOptions[field]', tabsOptions[field]);
     console.log('initialTabsOptions', initialTabsOptions);
+    
+    let tabsOptionsFiltered = Object.assign({}, tabsOptions[field]);
+    if (Object.keys(adminAppliedPreFilters).includes(field)) {
+      tabsOptionsFiltered.histogram = tabsOptionsFiltered.histogram.filter(x => 
+        adminAppliedPreFilters[field].selectedValues.includes(x.key)
+      );
+    }
+    console.log('tabOptionsFiltered: ', tabOptionsFiltered);
+
     let defaultOptions = getSingleFilterOption(
-      tabsOptions[field],
+      tabOptionsFiltered,
       initialTabsOptions ? initialTabsOptions[field] : undefined,
     );
 
-    if (Object.keys(adminAppliedPreFilters).includes(field)) {
-      let adminOptions = getSingleFilterOption(
-        adminAppliedPreFilters,
-        undefined
-      );
-
-      Object.assign(defaultOptions, adminOptions);
-    }
-    console.log('defaultOptions after Object.assign: ', defaultOptions);
+    
+    
     const rv = {
       title: label,
       options: defaultOptions,

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -53,6 +53,7 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
       ),
     };
   });
+  console.log('guppy utils.js line 56 sections: ', sections);
   return sections;
 };
 

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -55,7 +55,7 @@ export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabs
     let tabsOptionsFiltered = Object.assign({}, tabsOptions[field]);
     if (Object.keys(adminAppliedPreFilters).includes(field)) {
       tabsOptionsFiltered.histogram = tabsOptionsFiltered.histogram.filter(x => 
-        adminAppliedPreFilters[field].selectedValues.includes(x.key)
+        adminAppliedPreFilters[field].allowedValues.includes(x.key)
       );
     }
     console.log('tabsOptionsFiltered: ', tabsOptionsFiltered);

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -41,7 +41,8 @@ const capitalizeFirstLetter = (str) => {
   return res.replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 };
 
-export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabsOptions) => {
+export const getFilterSections = (fields, fieldMapping, tabsOptions, initialTabsOptions, adminAppliedPreFilters) => {
+  console.log('GUPPY GET FILTER SECTIONS ADMIN FILTERS ', adminAppliedPreFilters);
   const sections = fields.map((field) => {
     const overrideName = fieldMapping.find(entry => (entry.field === field));
     const label = overrideName ? overrideName.name : capitalizeFirstLetter(field);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -58,6 +58,9 @@ class GuppyWrapper extends React.Component {
       accessibility: ENUM_ACCESSIBILITY.ALL,
     };
     this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
+    Object.freeze(this.adminObjectReadOnly);
+    this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
+
   }
 
   /**
@@ -204,6 +207,7 @@ class GuppyWrapper extends React.Component {
   handleFilterChange(userFilter, accessibility) {
     console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters)));
     console.log('(205) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.adminObjectReadOnly)));
+    console.log('(206) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.adminObjectFrozenString);
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -48,9 +48,7 @@ class GuppyWrapper extends React.Component {
     super(props);
     // to avoid asynchronizations, we store another filter as private var
     this.filter = Object.assign({}, this.props.adminAppliedPreFilters);
-    this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
-    Object.freeze(this.adminObjectReadOnly);
-    this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
+    this.adminPreFiltersFrozen = JSON.stringify(this.props.adminAppliedPreFilters).slice();
     this.state = {
       aggsData: {},
       filter: Object.assign({}, this.props.adminAppliedPreFilters),
@@ -174,7 +172,7 @@ class GuppyWrapper extends React.Component {
   }
 
   handleFilterChange(userFilter, accessibility) {
-    this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
+    this.state.adminAppliedPreFilters = JSON.parse(this.adminPreFiltersFrozen);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.state.adminAppliedPreFilters).length > 0) {
       filter = mergeFilters(userFilter, this.state.adminAppliedPreFilters);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -172,7 +172,7 @@ class GuppyWrapper extends React.Component {
   }
 
   handleFilterChange(userFilter, accessibility) {
-    this.state.adminAppliedPreFilters = JSON.parse(this.adminPreFiltersFrozen);
+    this.setState({ adminAppliedPreFilters: JSON.parse(this.adminPreFiltersFrozen) });
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.state.adminAppliedPreFilters).length > 0) {
       filter = mergeFilters(userFilter, this.state.adminAppliedPreFilters);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -57,7 +57,7 @@ class GuppyWrapper extends React.Component {
       unaccessibleFieldObject: undefined,
       accessibility: ENUM_ACCESSIBILITY.ALL,
     };
-    Object.freeze(this.props.adminAppliedPreFilters);
+    this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
   }
 
   /**
@@ -203,6 +203,7 @@ class GuppyWrapper extends React.Component {
 
   handleFilterChange(userFilter, accessibility) {
     console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters)));
+    console.log('(205) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.adminObjectReadOnly)));
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -62,19 +62,19 @@ class GuppyWrapper extends React.Component {
   /**
    * This function takes two objects containing filters to be applied
    * and combines them into one filter object in the same format.
-  **/
+  * */
   mergeFilters(filterA, filterB) {
     console.log('guppy mergeFilters. filterA: ', filterA);
     console.log('guppy mergeFilters. filterB: ', filterB);
     const filterAB = Object.assign({}, filterA);
-    for (var key in filterB) {
-      if (Object.prototype.hasOwnProperty.call(filterA, key) && 
-          Object.prototype.hasOwnProperty.call(filterB, key)) {
+    for (const key in filterB) {
+      if (Object.prototype.hasOwnProperty.call(filterA, key)
+          && Object.prototype.hasOwnProperty.call(filterB, key)) {
         console.log('mergeFilters 72: ', key);
         filterAB[key].selectedValues = filterA[key].selectedValues.concat(
-          filterB[key].selectedValues
+          filterB[key].selectedValues,
         );
-      } else if(Object.prototype.hasOwnProperty.call(filterB, key)) {
+      } else if (Object.prototype.hasOwnProperty.call(filterB, key)) {
         filterAB[key] = filterB[key];
       }
     }
@@ -196,7 +196,7 @@ class GuppyWrapper extends React.Component {
   handleFilterChange(userFilter, accessibility) {
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign(userFilter);
-    if(Object.keys(this.props.adminAppliedPreFilters).length > 0) {
+    if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {
       console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
       filter = this.mergeFilters(userFilter, this.props.adminAppliedPreFilters);
     }
@@ -358,7 +358,7 @@ GuppyWrapper.propTypes = {
   onReceiveNewAggsData: PropTypes.func,
   onFilterChange: PropTypes.func,
   accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string),
-  adminAppliedPreFilters: PropTypes.object
+  adminAppliedPreFilters: PropTypes.object,
 };
 
 GuppyWrapper.defaultProps = {
@@ -366,7 +366,7 @@ GuppyWrapper.defaultProps = {
   onFilterChange: () => {},
   rawDataFields: [],
   accessibleFieldCheckList: undefined,
-  adminAppliedPreFilters: {}
+  adminAppliedPreFilters: {},
 };
 
 export default GuppyWrapper;

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -56,6 +56,7 @@ class GuppyWrapper extends React.Component {
       accessibleFieldObject: undefined,
       unaccessibleFieldObject: undefined,
       accessibility: ENUM_ACCESSIBILITY.ALL,
+      adminAppliedPreFilters: Object.assign({}, this.props.adminAppliedPreFilters),
     };
     this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
     Object.freeze(this.adminObjectReadOnly);
@@ -208,11 +209,15 @@ class GuppyWrapper extends React.Component {
     console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters)));
     console.log('(205) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.adminObjectReadOnly)));
     console.log('(206) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.adminObjectFrozenString);
+    console.log('(207) state prefilter before string assign ', this.state.adminAppliedPreFilters);
+    this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
+    console.log('(2089) state prefilter after string assign ', this.state.adminAppliedPreFilters);
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
+    this.props.
     let filter = Object.assign({}, userFilter);
-    if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {
+    if (Object.keys(this.state.adminAppliedPreFilters).length > 0) {
       console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
-      filter = this.mergeFilters(userFilter, this.props.adminAppliedPreFilters);
+      filter = this.mergeFilters(userFilter, this.state.adminAppliedPreFilters);
     }
     if (this.props.onFilterChange) {
       this.props.onFilterChange(filter);
@@ -319,6 +324,9 @@ class GuppyWrapper extends React.Component {
   render() {
     console.log('GUPPY WRAPPER 313 adminAppliedPreFilters: ', 
       JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters
+    )));
+    console.log('GUPPY WRAPPER 314 adminAppliedPreFilters: ', 
+      JSON.parse(JSON.stringify(this.state.adminAppliedPreFilters
     )));
     return (
       <React.Fragment>

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -9,6 +9,7 @@ import {
   askGuppyForNestedAggregationData,
 } from '../Utils/queries';
 import { ENUM_ACCESSIBILITY } from '../Utils/const';
+import { mergeFilters } from '../Utils/queries';
 
 /**
  * Wrapper that connects to Guppy server,
@@ -63,34 +64,6 @@ class GuppyWrapper extends React.Component {
     this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
 
   }
-
-  /**
-   * This function takes two objects containing filters to be applied
-   * and combines them into one filter object in the same format.
-   * Note: the admin filter takes precedence. Selected values in the user
-   * filter will be discarded if the key collides. This is to avoid
-   * the user undoing the admin filter. (Multiple user checkboxes increase the 
-   amount of data shown when combined, but an admin filter should always decrease
-   or keep constant the amount of dat shown when combined with a user filter).
-  * */
-  mergeFilters(userFilter, adminAppliedPreFilter) {
-    console.log('guppy mergeFilters. userFilter: ', userFilter);
-    console.log('guppy mergeFilters. adminAppliedPreFilter: ', adminAppliedPreFilter);
-    const filterAB = Object.assign({}, userFilter);
-    for (const key in adminAppliedPreFilter) {
-      if (Object.prototype.hasOwnProperty.call(userFilter, key)
-          && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-        console.log('mergeFilters 72: ', key);
-        // The admin filter overrides the user filter to maintain exclusivity.
-        filterAB[key].selectedValues = adminAppliedPreFilter[key].allowedValues;
-      } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-        filterAB[key] = { 'selectedValues' : adminAppliedPreFilter[key].allowedValues };
-      }
-    }
-    console.log('guppy mergeFilters. filterAB: ', filterAB);
-    return filterAB;
-  }
-
 
   componentDidMount() {
     getAllFieldsFromGuppy(
@@ -211,12 +184,12 @@ class GuppyWrapper extends React.Component {
     console.log('(206) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.adminObjectFrozenString);
     console.log('(207) state prefilter before string assign ', this.state.adminAppliedPreFilters);
     this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
-    console.log('(2089) state prefilter after string assign ', this.state.adminAppliedPreFilters);
+    console.log('(209) state prefilter after string assign ', this.state.adminAppliedPreFilters);
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.state.adminAppliedPreFilters).length > 0) {
       console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
-      filter = this.mergeFilters(userFilter, this.state.adminAppliedPreFilters);
+      filter = mergeFilters(userFilter, this.state.adminAppliedPreFilters);
     }
     if (this.props.onFilterChange) {
       this.props.onFilterChange(filter);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -1,3 +1,4 @@
+/* eslint react/forbid-prop-types: 0 */
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -45,7 +46,8 @@ import { mergeFilters } from '../Utils/filters';
 class GuppyWrapper extends React.Component {
   constructor(props) {
     super(props);
-    this.filter = Object.assign({}, this.props.adminAppliedPreFilters); // to avoid asynchronizations, we store another filter as private var
+    // to avoid asynchronizations, we store another filter as private var
+    this.filter = Object.assign({}, this.props.adminAppliedPreFilters);
     this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
     Object.freeze(this.adminObjectReadOnly);
     this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -67,7 +67,7 @@ class GuppyWrapper extends React.Component {
     console.log('guppy mergeFilters. filterA: ', filterA);
     console.log('guppy mergeFilters. filterB: ', filterB);
     const filterAB = Object.assign({}, filterA);
-    for (key in filterB) {
+    for (var key in filterB) {
       if (Object.prototype.hasOwnProperty.call(filterA, key)) {
         console.log('mergeFilters 72: ', key);
         filterAB[key].selectedValues = filterA[key].selectedValues.concat(

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -45,6 +45,7 @@ class GuppyWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.filter = {}; // to avoid asynchronizations, we store another filter as private var
+    console.log('inside guppywrapper constructor with adminAppliedPreFilters:', adminAppliedPreFilters);
     this.state = {
       aggsData: {},
       filter: {},
@@ -57,6 +58,25 @@ class GuppyWrapper extends React.Component {
       accessibility: ENUM_ACCESSIBILITY.ALL,
     };
   }
+
+  /**
+   * This function takes two objects containing filters to be applied
+   * and combines them into one filter object in the same format.
+  **/
+  mergeFilters(filterA, filterB) {
+    console.log('guppy mergeFilters. filterA: ', filterA);
+    console.log('guppy mergeFilters. filterB: ', filterB);
+    const filterAB = Object.assign({}, filterA);
+    for (key in filterB) {
+      if (Object.prototype.hasOwnProperty.call(filterA, key)) {
+        console.log('mergeFilters 72: ', key);
+        const filterA.selectedValues = [];
+      }
+    }
+    console.log('guppy mergeFilters. filterAB: ', filterAB);
+    return filterAB;
+  }
+
 
   componentDidMount() {
     getAllFieldsFromGuppy(
@@ -169,6 +189,12 @@ class GuppyWrapper extends React.Component {
   }
 
   handleFilterChange(filter, accessibility) {
+    console.log('guppy HANDLE FILTER CHANGE 192 filter:', filter);
+    let mergedFilter = filter;
+    if(Object.keys(this.props.adminAppliedPreFilters).length > 0) {
+      console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
+      mergedFilter = this.mergeFilters(filters, this.props.adminAppliedPreFilters);
+    }
     if (this.props.onFilterChange) {
       this.props.onFilterChange(filter);
     }
@@ -327,9 +353,7 @@ GuppyWrapper.propTypes = {
   onReceiveNewAggsData: PropTypes.func,
   onFilterChange: PropTypes.func,
   accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string),
-  adminFilterConfig: PropTypes.shape({
-    aggFields: PropTypes.array,
-  })
+  adminAppliedPreFilters: PropTypes.object
 };
 
 GuppyWrapper.defaultProps = {
@@ -337,6 +361,7 @@ GuppyWrapper.defaultProps = {
   onFilterChange: () => {},
   rawDataFields: [],
   accessibleFieldCheckList: undefined,
+  adminAppliedPreFilters: {}
 };
 
 export default GuppyWrapper;

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -96,6 +96,7 @@ class GuppyWrapper extends React.Component {
    * @param {number} size
    */
   getDataFromGuppy(fields, sort, updateDataWhenReceive, offset, size) {
+    console.log('GuppyWrapper line 99 -- getDataFromGuppy: ', fields, ' ', size, ' ', offset);
     if (!fields || fields.length === 0) {
       return Promise.resolve({ data: [], totalCount: 0 });
     }
@@ -152,6 +153,7 @@ class GuppyWrapper extends React.Component {
           totalCount,
         });
       }
+      console.log('returning from askGuppyForRawData callback in getDataFromGuppy: ', parsedData, ' and ', totalCount);
       return {
         data: parsedData,
         totalCount,

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -310,6 +310,7 @@ class GuppyWrapper extends React.Component {
   }
 
   render() {
+    console.log('GUPPY WRAPPER 313 adminAppliedPreFilters: ', this.props.adminAppliedPreFilters);
     return (
       <React.Fragment>
         {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -47,9 +47,12 @@ class GuppyWrapper extends React.Component {
     super(props);
     this.filter = {}; // to avoid asynchronizations, we store another filter as private var
     console.log('inside guppywrapper constructor with adminAppliedPreFilters:', this.props.adminAppliedPreFilters);
+    this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
+    Object.freeze(this.adminObjectReadOnly);
+    this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
     this.state = {
       aggsData: {},
-      filter: {},
+      filter: Object.assign({}, this.props.adminAppliedPreFilters),
       rawData: [],
       totalCount: 0,
       allFields: [],
@@ -59,10 +62,6 @@ class GuppyWrapper extends React.Component {
       accessibility: ENUM_ACCESSIBILITY.ALL,
       adminAppliedPreFilters: Object.assign({}, this.props.adminAppliedPreFilters),
     };
-    this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
-    Object.freeze(this.adminObjectReadOnly);
-    this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
-
   }
 
   componentDidMount() {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -78,7 +78,7 @@ class GuppyWrapper extends React.Component {
           && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
         console.log('mergeFilters 72: ', key);
         // The admin filter overrides the user filter to maintain exclusivity.
-        filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
+        filterAB[key].selectedValues = adminAppliedPreFilter[key].allowedValues;
       } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
         filterAB[key] = adminAppliedPreFilter[key];
       }

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -327,6 +327,9 @@ GuppyWrapper.propTypes = {
   onReceiveNewAggsData: PropTypes.func,
   onFilterChange: PropTypes.func,
   accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string),
+  adminFilterConfig: PropTypes.shape({
+    aggFields: PropTypes.array,
+  })
 };
 
 GuppyWrapper.defaultProps = {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -213,7 +213,6 @@ class GuppyWrapper extends React.Component {
     this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
     console.log('(2089) state prefilter after string assign ', this.state.adminAppliedPreFilters);
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
-    this.props.
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.state.adminAppliedPreFilters).length > 0) {
       console.log('guppy HANDLE FILTER CHANGE 194 merging filters');

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -62,20 +62,24 @@ class GuppyWrapper extends React.Component {
   /**
    * This function takes two objects containing filters to be applied
    * and combines them into one filter object in the same format.
+   * Note: the admin filter takes precedence. Selected values in the user
+   * filter will be discarded if the key collides. This is to avoid
+   * the user undoing the admin filter. (Multiple user checkboxes increase the 
+   amount of data shown when combined, but an admin filter should always decrease
+   or keep constant the amount of dat shown when combined with a user filter).
   * */
-  mergeFilters(filterA, filterB) {
-    console.log('guppy mergeFilters. filterA: ', filterA);
-    console.log('guppy mergeFilters. filterB: ', filterB);
-    const filterAB = Object.assign({}, filterA);
-    for (const key in filterB) {
-      if (Object.prototype.hasOwnProperty.call(filterA, key)
-          && Object.prototype.hasOwnProperty.call(filterB, key)) {
+  mergeFilters(userFilter, adminAppliedPreFilter) {
+    console.log('guppy mergeFilters. userFilter: ', userFilter);
+    console.log('guppy mergeFilters. adminAppliedPreFilter: ', adminAppliedPreFilter);
+    const filterAB = Object.assign({}, userFilter);
+    for (const key in adminAppliedPreFilter) {
+      if (Object.prototype.hasOwnProperty.call(userFilter, key)
+          && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
         console.log('mergeFilters 72: ', key);
-        filterAB[key].selectedValues = filterA[key].selectedValues.concat(
-          filterB[key].selectedValues,
-        );
-      } else if (Object.prototype.hasOwnProperty.call(filterB, key)) {
-        filterAB[key] = filterB[key];
+        // The admin filter overrides the user filter to maintain exclusivity.
+        filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
+      } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
+        filterAB[key] = adminAppliedPreFilter[key];
       }
     }
     console.log('guppy mergeFilters. filterAB: ', filterAB);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -45,7 +45,7 @@ import { mergeFilters } from '../Utils/filters';
 class GuppyWrapper extends React.Component {
   constructor(props) {
     super(props);
-    this.filter = {}; // to avoid asynchronizations, we store another filter as private var
+    this.filter = Object.assign({}, this.props.adminAppliedPreFilters); // to avoid asynchronizations, we store another filter as private var
     console.log('inside guppywrapper constructor with adminAppliedPreFilters:', this.props.adminAppliedPreFilters);
     this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
     Object.freeze(this.adminObjectReadOnly);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -195,7 +195,7 @@ class GuppyWrapper extends React.Component {
     let mergedFilter = filter;
     if(Object.keys(this.props.adminAppliedPreFilters).length > 0) {
       console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
-      mergedFilter = this.mergeFilters(filters, this.props.adminAppliedPreFilters);
+      mergedFilter = this.mergeFilters(filter, this.props.adminAppliedPreFilters);
     }
     if (this.props.onFilterChange) {
       this.props.onFilterChange(filter);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -198,7 +198,7 @@ class GuppyWrapper extends React.Component {
 
   handleFilterChange(userFilter, accessibility) {
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
-    let filter = Object.assign(userFilter);
+    let filter = Object.assign({}, userFilter);
     if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {
       console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
       filter = this.mergeFilters(userFilter, this.props.adminAppliedPreFilters);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -9,7 +9,7 @@ import {
   askGuppyForNestedAggregationData,
 } from '../Utils/queries';
 import { ENUM_ACCESSIBILITY } from '../Utils/const';
-import { mergeFilters } from '../Utils/queries';
+import { mergeFilters } from '../Utils/filters';
 
 /**
  * Wrapper that connects to Guppy server,

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -171,6 +171,9 @@ class GuppyWrapper extends React.Component {
         throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);
       }
       const parsedData = res.data[this.props.guppyConfig.type];
+      console.log(' DEBUG ME!!! askGuppyForRawData res', res);
+      console.log(' and res.data._aggregation', res.data._aggregation);
+      console.log(' and this.props.guppyConfig.type', this.props.guppyConfig.type);
       const totalCount = res.data._aggregation[this.props.guppyConfig.type]._totalCount;
       if (updateDataWhenReceive) {
         this.setState({

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -45,7 +45,7 @@ class GuppyWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.filter = {}; // to avoid asynchronizations, we store another filter as private var
-    console.log('inside guppywrapper constructor with adminAppliedPreFilters:', adminAppliedPreFilters);
+    console.log('inside guppywrapper constructor with adminAppliedPreFilters:', this.props.adminAppliedPreFilters);
     this.state = {
       aggsData: {},
       filter: {},

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -102,6 +102,7 @@ class GuppyWrapper extends React.Component {
    * @param {number} size
    */
   getDataFromGuppy(fields, sort, updateDataWhenReceive, offset, size) {
+    console.log('(-105-) inside getDataFromGuppy with', this.filter);
     console.log('GuppyWrapper line 99 -- getDataFromGuppy: ', fields, ' ', size, ' ', offset);
     if (!fields || fields.length === 0) {
       return Promise.resolve({ data: [], totalCount: 0 });
@@ -120,6 +121,7 @@ class GuppyWrapper extends React.Component {
         this.filter,
         this.state.accessibility,
       ).then((res) => {
+        console.log('124 res.data: ', res.data);
         if (!res || !res.data) {
           throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);
         }
@@ -148,6 +150,7 @@ class GuppyWrapper extends React.Component {
       size,
       this.state.accessibility,
     ).then((res) => {
+      console.log('153 res.data: ', res.data);
       if (!res || !res.data) {
         throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);
       }

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -80,7 +80,7 @@ class GuppyWrapper extends React.Component {
         // The admin filter overrides the user filter to maintain exclusivity.
         filterAB[key].selectedValues = adminAppliedPreFilter[key].allowedValues;
       } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-        filterAB[key] = adminAppliedPreFilter[key];
+        filterAB[key] = { 'selectedValues' : adminAppliedPreFilter[key].allowedValues };
       }
     }
     console.log('guppy mergeFilters. filterAB: ', filterAB);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -57,6 +57,7 @@ class GuppyWrapper extends React.Component {
       unaccessibleFieldObject: undefined,
       accessibility: ENUM_ACCESSIBILITY.ALL,
     };
+    Object.freeze(this.props.adminAppliedPreFilters);
   }
 
   /**

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -68,13 +68,14 @@ class GuppyWrapper extends React.Component {
     console.log('guppy mergeFilters. filterB: ', filterB);
     const filterAB = Object.assign({}, filterA);
     for (var key in filterB) {
-      if (Object.prototype.hasOwnProperty.call(filterA, key)) {
+      if (Object.prototype.hasOwnProperty.call(filterA, key) && 
+          Object.prototype.hasOwnProperty.call(filterB, key)) {
         console.log('mergeFilters 72: ', key);
         filterAB[key].selectedValues = filterA[key].selectedValues.concat(
           filterB[key].selectedValues
         );
-      } else {
-        filterAB.key = filterB.key;
+      } else if(Object.prototype.hasOwnProperty.call(filterB, key)) {
+        filterAB[key] = filterB[key];
       }
     }
     console.log('guppy mergeFilters. filterAB: ', filterAB);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -73,6 +73,8 @@ class GuppyWrapper extends React.Component {
         filterAB[key].selectedValues = filterA[key].selectedValues.concat(
           filterB[key].selectedValues
         );
+      } else {
+        filterAB.key = filterB.key;
       }
     }
     console.log('guppy mergeFilters. filterAB: ', filterAB);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -46,7 +46,6 @@ class GuppyWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.filter = Object.assign({}, this.props.adminAppliedPreFilters); // to avoid asynchronizations, we store another filter as private var
-    console.log('inside guppywrapper constructor with adminAppliedPreFilters:', this.props.adminAppliedPreFilters);
     this.adminObjectReadOnly = Object.assign({}, this.props.adminAppliedPreFilters);
     Object.freeze(this.adminObjectReadOnly);
     this.adminObjectFrozenString = JSON.stringify(this.adminObjectReadOnly).slice();
@@ -102,8 +101,6 @@ class GuppyWrapper extends React.Component {
    * @param {number} size
    */
   getDataFromGuppy(fields, sort, updateDataWhenReceive, offset, size) {
-    console.log('(-105-) inside getDataFromGuppy with', this.filter);
-    console.log('GuppyWrapper line 99 -- getDataFromGuppy: ', fields, ' ', size, ' ', offset);
     if (!fields || fields.length === 0) {
       return Promise.resolve({ data: [], totalCount: 0 });
     }
@@ -121,7 +118,6 @@ class GuppyWrapper extends React.Component {
         this.filter,
         this.state.accessibility,
       ).then((res) => {
-        console.log('124 res.data: ', res.data);
         if (!res || !res.data) {
           throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);
         }
@@ -150,14 +146,10 @@ class GuppyWrapper extends React.Component {
       size,
       this.state.accessibility,
     ).then((res) => {
-      console.log('153 res.data: ', res.data);
       if (!res || !res.data) {
         throw new Error(`Error getting raw ${this.props.guppyConfig.type} data from Guppy server ${this.props.guppyConfig.path}.`);
       }
       const parsedData = res.data[this.props.guppyConfig.type];
-      console.log(' DEBUG ME!!! askGuppyForRawData res', res);
-      console.log(' and res.data._aggregation', res.data._aggregation);
-      console.log(' and this.props.guppyConfig.type', this.props.guppyConfig.type);
       const totalCount = res.data._aggregation[this.props.guppyConfig.type]._totalCount;
       if (updateDataWhenReceive) {
         this.setState({
@@ -165,7 +157,6 @@ class GuppyWrapper extends React.Component {
           totalCount,
         });
       }
-      console.log('returning from askGuppyForRawData callback in getDataFromGuppy: ', parsedData, ' and ', totalCount);
       return {
         data: parsedData,
         totalCount,
@@ -181,16 +172,9 @@ class GuppyWrapper extends React.Component {
   }
 
   handleFilterChange(userFilter, accessibility) {
-    console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters)));
-    console.log('(205) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.adminObjectReadOnly)));
-    console.log('(206) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.adminObjectFrozenString);
-    console.log('(207) state prefilter before string assign ', this.state.adminAppliedPreFilters);
     this.state.adminAppliedPreFilters = JSON.parse(this.adminObjectFrozenString);
-    console.log('(209) state prefilter after string assign ', this.state.adminAppliedPreFilters);
-    console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.state.adminAppliedPreFilters).length > 0) {
-      console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
       filter = mergeFilters(userFilter, this.state.adminAppliedPreFilters);
     }
     if (this.props.onFilterChange) {
@@ -296,12 +280,6 @@ class GuppyWrapper extends React.Component {
   }
 
   render() {
-    console.log('GUPPY WRAPPER 313 adminAppliedPreFilters: ', 
-      JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters
-    )));
-    console.log('GUPPY WRAPPER 314 adminAppliedPreFilters: ', 
-      JSON.parse(JSON.stringify(this.state.adminAppliedPreFilters
-    )));
     return (
       <React.Fragment>
         {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -201,7 +201,7 @@ class GuppyWrapper extends React.Component {
   }
 
   handleFilterChange(userFilter, accessibility) {
-    console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.props.adminAppliedPreFilter);
+    console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.props.adminAppliedPreFilters);
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -336,6 +336,7 @@ class GuppyWrapper extends React.Component {
             onFilterChange: this.handleFilterChange.bind(this),
             guppyConfig: this.props.guppyConfig,
             onUpdateAccessLevel: this.handleAccessLevelUpdate.bind(this),
+            adminAppliedPreFilters: this.props.adminAppliedPreFilters,
           }))
         }
       </React.Fragment>

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -201,7 +201,7 @@ class GuppyWrapper extends React.Component {
   }
 
   handleFilterChange(userFilter, accessibility) {
-    console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.props.adminAppliedPreFilters);
+    console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters)));
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {
@@ -311,7 +311,9 @@ class GuppyWrapper extends React.Component {
   }
 
   render() {
-    console.log('GUPPY WRAPPER 313 adminAppliedPreFilters: ', this.props.adminAppliedPreFilters);
+    console.log('GUPPY WRAPPER 313 adminAppliedPreFilters: ', 
+      JSON.parse(JSON.stringify(this.props.adminAppliedPreFilters
+    )));
     return (
       <React.Fragment>
         {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -193,12 +193,12 @@ class GuppyWrapper extends React.Component {
     this.setState({ aggsData });
   }
 
-  handleFilterChange(filter, accessibility) {
-    console.log('guppy HANDLE FILTER CHANGE 192 filter:', filter);
-    let mergedFilter = filter;
+  handleFilterChange(userFilter, accessibility) {
+    console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
+    let filter = Object.assign(userFilter);
     if(Object.keys(this.props.adminAppliedPreFilters).length > 0) {
       console.log('guppy HANDLE FILTER CHANGE 194 merging filters');
-      mergedFilter = this.mergeFilters(filter, this.props.adminAppliedPreFilters);
+      filter = this.mergeFilters(userFilter, this.props.adminAppliedPreFilters);
     }
     if (this.props.onFilterChange) {
       this.props.onFilterChange(filter);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -70,7 +70,9 @@ class GuppyWrapper extends React.Component {
     for (key in filterB) {
       if (Object.prototype.hasOwnProperty.call(filterA, key)) {
         console.log('mergeFilters 72: ', key);
-        const filterA.selectedValues = [];
+        filterAB[key].selectedValues = filterA[key].selectedValues.concat(
+          filterB[key].selectedValues
+        );
       }
     }
     console.log('guppy mergeFilters. filterAB: ', filterAB);

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -201,6 +201,7 @@ class GuppyWrapper extends React.Component {
   }
 
   handleFilterChange(userFilter, accessibility) {
+    console.log('(204) GUPPY WRAPPER HANDLE FILTER CHANGE! ', this.props.adminAppliedPreFilter);
     console.log('guppy HANDLE FILTER CHANGE 192 filter:', userFilter);
     let filter = Object.assign({}, userFilter);
     if (Object.keys(this.props.adminAppliedPreFilters).length > 0) {

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -1,0 +1,26 @@
+/**
+   * This function takes two objects containing filters to be applied
+   * and combines them into one filter object in the same format.
+   * Note: the admin filter takes precedence. Selected values in the user
+   * filter will be discarded if the key collides. This is to avoid
+   * the user undoing the admin filter. (Multiple user checkboxes increase the 
+   amount of data shown when combined, but an admin filter should always decrease
+   or keep constant the amount of dat shown when combined with a user filter).
+  * */
+  mergeFilters(userFilter, adminAppliedPreFilter) {
+    console.log('guppy mergeFilters. userFilter: ', userFilter);
+    console.log('guppy mergeFilters. adminAppliedPreFilter: ', adminAppliedPreFilter);
+    const filterAB = Object.assign({}, userFilter);
+    for (const key in adminAppliedPreFilter) {
+      if (Object.prototype.hasOwnProperty.call(userFilter, key)
+          && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
+        console.log('mergeFilters 72: ', key);
+        // The admin filter overrides the user filter to maintain exclusivity.
+        filterAB[key].selectedValues = adminAppliedPreFilter[key].allowedValues;
+      } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
+        filterAB[key] = { 'selectedValues' : adminAppliedPreFilter[key].allowedValues };
+      }
+    }
+    console.log('guppy mergeFilters. filterAB: ', filterAB);
+    return filterAB;
+  }

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -7,7 +7,7 @@
    amount of data shown when combined, but an admin filter should always decrease
    or keep constant the amount of dat shown when combined with a user filter).
   * */
-  mergeFilters(userFilter, adminAppliedPreFilter) {
+  export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
     console.log('guppy mergeFilters. userFilter: ', userFilter);
     console.log('guppy mergeFilters. adminAppliedPreFilter: ', adminAppliedPreFilter);
     const filterAB = Object.assign({}, userFilter);

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -16,9 +16,9 @@
           && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
         console.log('mergeFilters 72: ', key);
         // The admin filter overrides the user filter to maintain exclusivity.
-        filterAB[key].selectedValues = adminAppliedPreFilter[key].allowedValues;
+        filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
       } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-        filterAB[key] = { 'selectedValues' : adminAppliedPreFilter[key].allowedValues };
+        filterAB[key] = { 'selectedValues' : adminAppliedPreFilter[key].selectedValues };
       }
     }
     console.log('guppy mergeFilters. filterAB: ', filterAB);

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -14,11 +14,10 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   Object.keys(adminAppliedPreFilter).forEach((key) => {
     if (Object.prototype.hasOwnProperty.call(userFilter, key)
           && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-
       const userFilterSubset = userFilter[key].selectedValues.filter(
-        x => adminAppliedPreFilter[key].selectedValues.includes(x)
+        x => adminAppliedPreFilter[key].selectedValues.includes(x),
       );
-      if(userFilterSubset.length > 0) {
+      if (userFilterSubset.length > 0) {
         // The user-applied filter is more exclusive than the admin-applied filter.
         filterAB[key].selectedValues = userFilter[key].selectedValues;
       } else {

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -14,8 +14,17 @@ export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   Object.keys(adminAppliedPreFilter).forEach((key) => {
     if (Object.prototype.hasOwnProperty.call(userFilter, key)
           && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-      // The admin filter overrides the user filter to maintain exclusivity.
-      filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
+
+      const userFilterSubset = userFilter[key].selectedValues.filter(
+        x => adminAppliedPreFilter[key].selectedValues.includes(x)
+      );
+      if(userFilterSubset.length > 0) {
+        // The user-applied filter is more exclusive than the admin-applied filter.
+        filterAB[key].selectedValues = userFilter[key].selectedValues;
+      } else {
+        // The admin-applied filter is more exclusive than the user-applied filter.
+        filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
+      }
     } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
       filterAB[key] = { selectedValues: adminAppliedPreFilter[key].selectedValues };
     }

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -1,22 +1,25 @@
+/* eslint import/prefer-default-export: 0 */
+
 /**
    * This function takes two objects containing filters to be applied
    * and combines them into one filter object in the same format.
    * Note: the admin filter takes precedence. Selected values in the user
    * filter will be discarded if the key collides. This is to avoid
-   * the user undoing the admin filter. (Multiple user checkboxes increase the 
+   * the user undoing the admin filter. (Multiple user checkboxes increase the
    amount of data shown when combined, but an admin filter should always decrease
    or keep constant the amount of dat shown when combined with a user filter).
   * */
-  export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
-    const filterAB = Object.assign({}, userFilter);
-    for (const key in adminAppliedPreFilter) {
-      if (Object.prototype.hasOwnProperty.call(userFilter, key)
+export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
+  const filterAB = Object.assign({}, userFilter);
+  Object.keys(adminAppliedPreFilter).forEach((key) => {
+    if (Object.prototype.hasOwnProperty.call(userFilter, key)
           && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-        // The admin filter overrides the user filter to maintain exclusivity.
-        filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
-      } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-        filterAB[key] = { 'selectedValues' : adminAppliedPreFilter[key].selectedValues };
-      }
+      // The admin filter overrides the user filter to maintain exclusivity.
+      filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
+    } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
+      filterAB[key] = { selectedValues: adminAppliedPreFilter[key].selectedValues };
     }
-    return filterAB;
-  };
+  });
+
+  return filterAB;
+};

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -23,4 +23,4 @@
     }
     console.log('guppy mergeFilters. filterAB: ', filterAB);
     return filterAB;
-  }
+  };

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -6,8 +6,8 @@
    * Note: the admin filter takes precedence. Selected values in the user
    * filter will be discarded if the key collides. This is to avoid
    * the user undoing the admin filter. (Multiple user checkboxes increase the
-   amount of data shown when combined, but an admin filter should always decrease
-   or keep constant the amount of dat shown when combined with a user filter).
+   * amount of data shown when combined, but an admin filter should always decrease
+   * or keep constant the amount of data shown when combined with a user filter).
   * */
 export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
   const filterAB = Object.assign({}, userFilter);

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -8,19 +8,15 @@
    or keep constant the amount of dat shown when combined with a user filter).
   * */
   export const mergeFilters = (userFilter, adminAppliedPreFilter) => {
-    console.log('guppy mergeFilters. userFilter: ', userFilter);
-    console.log('guppy mergeFilters. adminAppliedPreFilter: ', adminAppliedPreFilter);
     const filterAB = Object.assign({}, userFilter);
     for (const key in adminAppliedPreFilter) {
       if (Object.prototype.hasOwnProperty.call(userFilter, key)
           && Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
-        console.log('mergeFilters 72: ', key);
         // The admin filter overrides the user filter to maintain exclusivity.
         filterAB[key].selectedValues = adminAppliedPreFilter[key].selectedValues;
       } else if (Object.prototype.hasOwnProperty.call(adminAppliedPreFilter, key)) {
         filterAB[key] = { 'selectedValues' : adminAppliedPreFilter[key].selectedValues };
       }
     }
-    console.log('guppy mergeFilters. filterAB: ', filterAB);
     return filterAB;
   };

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -12,6 +12,7 @@ const histogramQueryStrForEachField = field => (`
   }`);
 
 const queryGuppyForAggs = (path, type, fields, gqlFilter, acc) => {
+  console.log('queries.js line 15 queryGuppyForAggs, filter: ', filter);
   let accessibility = acc;
   if (accessibility !== 'all' && accessibility !== 'accessible' && accessibility !== 'unaccessible') {
     accessibility = 'all';

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -12,7 +12,7 @@ const histogramQueryStrForEachField = field => (`
   }`);
 
 const queryGuppyForAggs = (path, type, fields, gqlFilter, acc) => {
-  console.log('queries.js line 15 queryGuppyForAggs, filter: ', filter);
+  console.log('queries.js line 15 queryGuppyForAggs, filter: ', gqlFilter);
   let accessibility = acc;
   if (accessibility !== 'all' && accessibility !== 'accessible' && accessibility !== 'unaccessible') {
     accessibility = 'all';

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -168,8 +168,8 @@ const queryGuppyForRawDataAndTotalCounts = (
 };
 
 export const askGuppyAboutAllFieldsAndOptions = (
-  path, type, fields, accessibility,
-) => queryGuppyForAggs(path, type, fields, undefined, accessibility);
+  path, type, fields, accessibility, filter
+) => queryGuppyForAggs(path, type, fields, filter, accessibility);
 
 export const getGQLFilter = (filterObj) => {
   const facetsList = [];

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -167,13 +167,6 @@ const queryGuppyForRawDataAndTotalCounts = (
     });
 };
 
-export const askGuppyAboutAllFieldsAndOptions = (
-  path, type, fields, accessibility, filter
-) => { 
-  const gqlFilter = getGQLFilter(filter);
-  return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility); 
-}
-
 export const getGQLFilter = (filterObj) => {
   const facetsList = [];
   Object.keys(filterObj).forEach((field) => {
@@ -199,6 +192,13 @@ export const getGQLFilter = (filterObj) => {
     AND: facetsList,
   };
   return gqlFilter;
+};
+
+export const askGuppyAboutAllFieldsAndOptions = (
+  path, type, fields, accessibility, filter,
+) => {
+  const gqlFilter = getGQLFilter(filter);
+  return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility);
 };
 
 export const askGuppyForAggregationData = (path, type, fields, filter, accessibility) => {

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -12,7 +12,6 @@ const histogramQueryStrForEachField = field => (`
   }`);
 
 const queryGuppyForAggs = (path, type, fields, gqlFilter, acc) => {
-  console.log('queries.js line 15 queryGuppyForAggs, filter: ', gqlFilter);
   let accessibility = acc;
   if (accessibility !== 'all' && accessibility !== 'accessible' && accessibility !== 'unaccessible') {
     accessibility = 'all';
@@ -172,7 +171,6 @@ export const askGuppyAboutAllFieldsAndOptions = (
   path, type, fields, accessibility, filter
 ) => { 
   const gqlFilter = getGQLFilter(filter);
-  console.log('175 askGuppyAboutAllFieldsAndOptions: ', gqlFilter);
   return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility); 
 }
 

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -169,8 +169,12 @@ const queryGuppyForRawDataAndTotalCounts = (
 };
 
 export const askGuppyAboutAllFieldsAndOptions = (
-  path, type, fields, accessibility, gqlFilter
-) => queryGuppyForAggs(path, type, fields, gqlFilter, accessibility);
+  path, type, fields, accessibility, filter
+) => { 
+  const gqlFilter = getGQLFilter(filter);
+  console.log('175 askGuppyAboutAllFieldsAndOptions: ', gqlFilter);
+  return queryGuppyForAggs(path, type, fields, gqlFilter, accessibility); 
+}
 
 export const getGQLFilter = (filterObj) => {
   const facetsList = [];

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -168,8 +168,8 @@ const queryGuppyForRawDataAndTotalCounts = (
 };
 
 export const askGuppyAboutAllFieldsAndOptions = (
-  path, type, fields, accessibility, filter
-) => queryGuppyForAggs(path, type, fields, filter, accessibility);
+  path, type, fields, accessibility, gqlFilter
+) => queryGuppyForAggs(path, type, fields, gqlFilter, accessibility);
 
 export const getGQLFilter = (filterObj) => {
   const facetsList = [];

--- a/src/components/__tests__/filters.test.js
+++ b/src/components/__tests__/filters.test.js
@@ -1,0 +1,24 @@
+/* eslint-disable global-require,import/no-dynamic-require */
+// Tests for Utils/filters.js
+
+import {
+  mergeFilters
+} from '../Utils/filters';
+
+console.log('\n\n\ninside filters.test.js\n\n\n');
+
+describe('filters', () => {
+  const filterA = { project_id: { selectedValues : ['jenkins-jnkns'] } };
+  const filterB = { data_format: { selectedValues : ['VCF'] } };
+
+  const filterABExpected = { 
+  	project_id: { selectedValues : ['jenkins-jnkns'] },
+  	data_format: { selectedValues : ['VCF'] }
+  }
+
+  test('merge filters', async () => {
+    const filterAB = mergeFilters(config.esConfig);
+    expect(removeSpacesNewlinesAndDescriptions(querySchema))
+      .toEqual(filterABExpected);
+  });
+});

--- a/src/components/__tests__/filters.test.js
+++ b/src/components/__tests__/filters.test.js
@@ -1,24 +1,41 @@
 /* eslint-disable global-require,import/no-dynamic-require */
 // Tests for Utils/filters.js
+import { mergeFilters } from '../Utils/filters';
 
-import {
-  mergeFilters
-} from '../Utils/filters';
+describe('can merge simple selectedValue filters', () => {
+  const userFilter = { data_format: { selectedValues: ['VCF'] } };
+  const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins'] } };
 
-console.log('\n\n\ninside filters.test.js\n\n\n');
-
-describe('filters', () => {
-  const filterA = { project_id: { selectedValues : ['jenkins-jnkns'] } };
-  const filterB = { data_format: { selectedValues : ['VCF'] } };
-
-  const filterABExpected = { 
-  	project_id: { selectedValues : ['jenkins-jnkns'] },
-  	data_format: { selectedValues : ['VCF'] }
-  }
+  const mergedFilterExpected = {
+  	project_id: { selectedValues: ['jnkns-jenkins'] },
+  	data_format: { selectedValues: ['VCF'] },
+  };
 
   test('merge filters', async () => {
-    const filterAB = mergeFilters(config.esConfig);
-    expect(removeSpacesNewlinesAndDescriptions(querySchema))
-      .toEqual(filterABExpected);
+    const mergedFilter = mergeFilters(userFilter, adminFilter);
+    expect(mergedFilter)
+      .toEqual(mergedFilterExpected);
+  });
+});
+
+describe('can merge admin-provided selectedValue filters with user-provided range filters', () => {
+  const userFilter = {
+    bmi: { lowerBound: 28, upperBound: 99 },
+    age: { lowerBound: 26, upperBound: 33 },
+    data_type: { selectedValues: ["Aligned Reads"] }
+  };
+  const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] } };
+
+  const mergedFilterExpected = {
+    project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] },
+    bmi: { lowerBound: 28, upperBound: 99 },
+    age: { lowerBound: 26, upperBound: 33 },
+    data_type: { selectedValues: ["Aligned Reads"] }
+  };
+
+  test('merge filters', async () => {
+    const mergedFilter = mergeFilters(userFilter, adminFilter);
+    expect(mergedFilter)
+      .toEqual(mergedFilterExpected);
   });
 });

--- a/src/components/__tests__/filters.test.js
+++ b/src/components/__tests__/filters.test.js
@@ -7,8 +7,8 @@ describe('can merge simple selectedValue filters', () => {
   const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins'] } };
 
   const mergedFilterExpected = {
-  	project_id: { selectedValues: ['jnkns-jenkins'] },
-  	data_format: { selectedValues: ['VCF'] },
+    project_id: { selectedValues: ['jnkns-jenkins'] },
+    data_format: { selectedValues: ['VCF'] },
   };
 
   test('merge filters', async () => {
@@ -22,7 +22,7 @@ describe('can merge admin-provided selectedValue filters with user-provided rang
   const userFilter = {
     bmi: { lowerBound: 28, upperBound: 99 },
     age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ["Aligned Reads"] }
+    data_type: { selectedValues: ['Aligned Reads'] },
   };
   const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] } };
 
@@ -30,7 +30,7 @@ describe('can merge admin-provided selectedValue filters with user-provided rang
     project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] },
     bmi: { lowerBound: 28, upperBound: 99 },
     age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ["Aligned Reads"] }
+    data_type: { selectedValues: ['Aligned Reads'] },
   };
 
   test('merge filters', async () => {
@@ -44,14 +44,14 @@ describe('will select user-applied filter for a given key if it is more exclusiv
   const userFilter = {
     project_id: { selectedValues: ['jnkns-jenkins2'] },
     age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ["Aligned Reads"] }
+    data_type: { selectedValues: ['Aligned Reads'] },
   };
   const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] } };
 
   const mergedFilterExpected = {
     project_id: { selectedValues: ['jnkns-jenkins2'] },
     age: { lowerBound: 26, upperBound: 33 },
-    data_type: { selectedValues: ["Aligned Reads"] }
+    data_type: { selectedValues: ['Aligned Reads'] },
   };
 
   test('merge filters', async () => {

--- a/src/components/__tests__/filters.test.js
+++ b/src/components/__tests__/filters.test.js
@@ -39,3 +39,24 @@ describe('can merge admin-provided selectedValue filters with user-provided rang
       .toEqual(mergedFilterExpected);
   });
 });
+
+describe('will select user-applied filter for a given key if it is more exclusive than admin filter', () => {
+  const userFilter = {
+    project_id: { selectedValues: ['jnkns-jenkins2'] },
+    age: { lowerBound: 26, upperBound: 33 },
+    data_type: { selectedValues: ["Aligned Reads"] }
+  };
+  const adminFilter = { project_id: { selectedValues: ['jnkns-jenkins', 'jnkns-jenkins2'] } };
+
+  const mergedFilterExpected = {
+    project_id: { selectedValues: ['jnkns-jenkins2'] },
+    age: { lowerBound: 26, upperBound: 33 },
+    data_type: { selectedValues: ["Aligned Reads"] }
+  };
+
+  test('merge filters', async () => {
+    const mergedFilter = mergeFilters(userFilter, adminFilter);
+    expect(mergedFilter)
+      .toEqual(mergedFilterExpected);
+  });
+});


### PR DESCRIPTION
### New Features
- Guppy support for portal's new config option `adminPreAppliedFilters`. The filter is applied to to the records displayed before any user-applied filters, and can be specified independently in the dataExplorerConfig and fileExplorerConfig blocks. 

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- Commons admins can specify a selectedValues filter using the `adminPreAppliedFilters` field in a portal config file using Guppy syntax. The filter is applied to to the records displayed before any user-applied filters, and can be specified independently in the dataExplorerConfig and fileExplorerConfig blocks. Example: 
```
"adminAppliedPreFilters": {
      "project_id": { 
        "selectedValues": ["jnkns-jenkins"]
      }
    }
```