### PR TITLE
Fix/long

### DIFF
--- a/devHelper/scripts/commands.sh
+++ b/devHelper/scripts/commands.sh
@@ -56,7 +56,8 @@ curl -iv -X PUT "${ESHOST}/${indexName}" \
           "file_count": { "type": "integer" },
           "whatever_lab_result_value": { "type": "float" },
           "some_string_field": { "type": "keyword" },
-          "some_integer_field": { "type": "integer" }
+          "some_integer_field": { "type": "integer" },
+          "some_long_field": { "type": "long" }
         }
       }
     }
@@ -156,6 +157,7 @@ while [[ $COUNT -lt $endIndex ]]; do
   randomFloatNumber="$(( $RANDOM % 100 )).$(( $RANDOM % 100 ))"
   stringArray='["1", "2"]'
   intArray='[1, 2]'
+  longNumber="10737418240"
 
   cat - > "$tmpName" <<EOM
 {
@@ -173,7 +175,8 @@ while [[ $COUNT -lt $endIndex ]]; do
   "file_count": $fileCounts,
   "whatever_lab_result_value": $randomFloatNumber,
   "some_string_field": $stringArray,
-  "some_integer_field": $intArray
+  "some_integer_field": $intArray,
+  "some_long_field": $longNumber
 }
 EOM
   cat - $tmpName <<EOM

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -238,6 +238,9 @@ const mockESMapping = () => {
             file_id: {
               type: 'keyword',
             },
+            file_size: {
+              type: 'long',
+            },
             subject_id: {
               type: 'keyword',
             },

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -62,6 +62,7 @@ describe('Schema', () => {
     type File {
       gen3_resource_path: String,
       file_id: String,
+      file_size: Float,
       subject_id: String,
     }`;
   test('could create type schemas', async () => {
@@ -107,6 +108,7 @@ describe('Schema', () => {
       _totalCount: Int
       gen3_resource_path: HistogramForString,
       file_id: HistogramForString,
+      file_size: HistogramForNumber,
       subject_id: HistogramForString,
     }`;
   test('could create aggregation schemas for each type', async () => {

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -6,7 +6,7 @@ const esgqlTypeMapping = {
   text: 'String',
   keyword: 'String',
   integer: 'Int',
-  long: 'Int',
+  long: 'Float',
   short: 'Int',
   byte: 'Int',
   double: 'Float',


### PR DESCRIPTION
For integers geatear than 32-bit int such as 10737418240, there will be an error if we map `long` to GQL `Int` type. The error message looks like `"message": "Int cannot represent non 32-bit signed integer value: 10737418240"`

We could either use a customized scalar or just map `long` to GQL `Float` type

### New Features


### Breaking Changes


### Bug Fixes
- fixed an error when result contains 64-bit numeric values

### Improvements


### Dependency updates


### Deployment changes

