### PR TITLE
Fix/authz no user

### DIFF
--- a/src/server/auth/utils.js
+++ b/src/server/auth/utils.js
@@ -21,6 +21,10 @@ export const getAccessibleResourcesFromArboristasync = async (jwt) => {
 
   log.debug('[authMiddleware] list resources: ', JSON.stringify(data, null, 4));
   if (data && data.error) {
+    // if user is not in arborist db
+    if (data.error.code === 404) {
+      return [];
+    }
     throw new CodedError(data.error.code, data.error.message);
   }
   const resources = data.resources ? _.uniq(data.resources) : [];

--- a/src/server/auth/utils.js
+++ b/src/server/auth/utils.js
@@ -21,7 +21,7 @@ export const getAccessibleResourcesFromArboristasync = async (jwt) => {
 
   log.debug('[authMiddleware] list resources: ', JSON.stringify(data, null, 4));
   if (data && data.error) {
-    // if user is not in arborist db
+    // if user is not in arborist db, assume has no access to any
     if (data.error.code === 404) {
       return [];
     }

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -34,7 +34,7 @@ log.levelEnums = {
   SILENT: 5,
 };
 
-log.setLevel('DEBUG');
+log.setLevel('INFO');
 log.setLogLevel = (level) => {
   if (!Object.keys(numLevels).includes(level) && !Object.keys(log.levelEnums).includes(level)) {
     throw new Error(`Invalid log level ${level}`);

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -34,7 +34,7 @@ log.levelEnums = {
   SILENT: 5,
 };
 
-log.setLevel('INFO');
+log.setLevel('DEBUG');
 log.setLogLevel = (level) => {
   if (!Object.keys(numLevels).includes(level) && !Object.keys(log.levelEnums).includes(level)) {
     throw new Error(`Invalid log level ${level}`);


### PR DESCRIPTION
From Arborist 2.2.0 https://github.com/uc-cdis/arborist/releases/tag/2.2.0 if a user doesn't exist in Arobrist DB then an `404: user does not exist` response is returned instead of a blank JSON object if hitting the /auth/resources end point. This is causing Guppy to fail in tiered access mode.

### New Features


### Breaking Changes


### Bug Fixes
- fixed a bug that is causing Guppy AuthHelper to crash if a user does not exist in the arborist DB

### Improvements


### Dependency updates


### Deployment changes

