### PR TITLE
(PXP-5570) Bump header size limit to 16kb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,5 @@ RUN npm run-script prepare
 EXPOSE 3000
 EXPOSE 80
 
-CMD node dist/server/server.js
+CMD node --max-http-header-size 16000 dist/server/server.js
 


### PR DESCRIPTION
Resolves https://ctds-planx.atlassian.net/browse/PXP-5570 (Users see 0 projects in explorer)
This issue was caused by large session cookies set during NIH login causing request over 8kb in size being sent to guppy's nodejs server. This commit doubles guppy's request header size, which should prevent the problem from reoccuring.

### Deployment changes
- Increased node.js max header size to prevent issue with large NIH login session cookies hitting request header limit.
