### PR TITLE
PXP-5773 Fix/no jwt 401

### DIFF
--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -203,7 +203,7 @@ const mockResourcePath = () => {
 const mockArborist = () => {
   nock(config.arboristEndpoint)
     .persist()
-    .post('/auth/resources')
+    .get('/auth/resources')
     .reply(200, {
       resources: [
         'internal-project-1',

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -9,21 +9,15 @@ class ArboristClient {
   }
 
   listAuthorizedResources(jwt) {
-    if (!jwt) {
-      log.error('[ArboristClient] jwt token undefined');
-      throw new CodedError(401, 'not authorized');
-    }
     // Make request to arborist for list of resources with access
     const resourcesEndpoint = `${this.baseEndpoint}/auth/resources`;
     log.debug('[ArboristClient] listAuthorizedResources jwt: ', jwt);
+    const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
     return fetch(
       resourcesEndpoint,
       {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ user: { token: jwt } }),
+        method: 'GET',
+        headers,
       },
     ).then(
       (response) => response.json(),


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-5773

Since Arborist now has policies for unauthenticated users, Guppy should now simply returns 401 if user doesn't have JWT.

This is achieved by changing the way that Guppy is interacting with the `/auth/resources` endpoint from `POST` to `GET`

Deployed to https://mingfei.planx-pla.net/

### Improvements
- Guppy will not always return 401 for user who doesn't have a JWT


