### PR TITLE
feat(wrapper-size)

### DIFF
--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -276,7 +276,7 @@ class GuppyWrapper extends React.Component {
       filter,
       this.state.accessibility,
     )
-      .then(count => downloadDataFromGuppy(
+      .then((count) => downloadDataFromGuppy(
         this.props.guppyConfig.path,
         type,
         count,
@@ -295,7 +295,7 @@ class GuppyWrapper extends React.Component {
     return (
       <>
         {
-          React.Children.map(this.props.children, child => React.cloneElement(child, {
+          React.Children.map(this.props.children, (child) => React.cloneElement(child, {
             // pass data to children
             aggsData: this.state.aggsData,
             aggsDataIsLoading: this.state.gettingDataFromGuppy,

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -76,7 +76,13 @@ class GuppyWrapper extends React.Component {
         allFields: fields,
         rawDataFields,
       }, () => {
-        this.getDataFromGuppy(this.state.rawDataFields, undefined, true);
+        this.getDataFromGuppy(
+          this.state.rawDataFields,
+          undefined,
+          true,
+          this.props.guppyConfig.offset,
+          this.props.guppyConfig.size,
+        );
       });
     });
     if (typeof this.props.accessibleFieldCheckList !== 'undefined') {
@@ -270,7 +276,7 @@ class GuppyWrapper extends React.Component {
       filter,
       this.state.accessibility,
     )
-      .then((count) => downloadDataFromGuppy(
+      .then(count => downloadDataFromGuppy(
         this.props.guppyConfig.path,
         type,
         count,
@@ -289,7 +295,7 @@ class GuppyWrapper extends React.Component {
     return (
       <>
         {
-          React.Children.map(this.props.children, (child) => React.cloneElement(child, {
+          React.Children.map(this.props.children, child => React.cloneElement(child, {
             // pass data to children
             aggsData: this.state.aggsData,
             aggsDataIsLoading: this.state.gettingDataFromGuppy,
@@ -329,6 +335,8 @@ GuppyWrapper.propTypes = {
     mainField: PropTypes.string,
     mainFieldIsNumeric: PropTypes.bool,
     aggFields: PropTypes.array,
+    size: PropTypes.number,
+    offset: PropTypes.number,
   }).isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -58,7 +58,7 @@ class ES {
       type: esType,
       body: validatedQueryBody,
     }).then((resp) => resp.body, (err) => {
-      log.error('[ES.query] error during querying');
+      log.error('[ES.query] error during querying: ' + err.message);
       throw new Error(err.message);
     });
   }


### PR DESCRIPTION
I need to get _all_ the data, and the GuppyWrapper defaults to returning only the first 20. When we have more than 10,000 documents in ES it will also be a problem, because we can't get more than 10,000 with the Guppy Wrapper. Would need to use the download endpoint instead

Any suggestions better than this PR to solve this problem are welcome!!

I am also forced to filter the `project_id` on the client side because I didn't find a way to do it through the GuppyWrapper config - also would love suggestions on that! Maybe everything can be solved by using the download endpoint instead of GuppyWrapper

### Improvements
- Allow specifying a `size` and an `offset` in the GuppyWrapper config
