### PR TITLE
PXP-4737 Feat/nested agg

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Please see [this doc](https://github.com/uc-cdis/guppy/blob/master/doc/queries.m
 
 Run `npm start` to start server at port 80.
 
+### Local Deployment and Development:
+Guppy has some helper script to help a developer to set up a local ES service using Docker, generate some example ES indices for testing, and pop mock data into these example ES indices. Please refer to [the DEV Helper doc](https://github.com/uc-cdis/guppy/blob/master/devHelper/README.md) for more information.
+
 ### Configurations:
 Before launch, we need to write config and tell Guppy which elasticsearch indices and which auth control field to use.
 You could put following as your config files:
@@ -40,7 +43,7 @@ export GUPPY_CONFIG_FILEPATH=./example_config.json
 npm start
 ```
 
-#### Authorization
+### Authorization:
 Guppy connects Arborist for authorization.
 The `auth_filter_field` item in your config file is the field used for authorization.
 You could set the endpoint by:
@@ -54,7 +57,7 @@ skip all authorization steps. But if you just want to mock your own authorizatio
 behavior for local test without Arborist, just set `INTERNAL_LOCAL_TEST=true`. Please
 look into `/src/server/auth/utils.js` for more details.
 
-#### Tier access
+### Tiered Access:
 Guppy also support 3 different levels of tier access, by setting `TIER_ACCESS_LEVEL`:
 - `private` by default: only allows access to authorized resources
 - `regular`: allows all kind of aggregation (with limitation for unauthorized resources), but forbid access to raw data without authorization
@@ -94,7 +97,7 @@ export TIER_ACCESS_LIMIT=100
 npm start
 ```
 
-> ##### Tier Access Sensitive Record Exclusion
+> #### Tier Access Sensitive Record Exclusion
 > It is possible to configure Guppy to hide some records from being returned in `_aggregation` queries when Tiered Access is enabled (tierAccessLevel: "regular").
 > The purpose of this is to "hide" information about certain sensitive resources, essentially making this an escape hatch from Tiered Access.
 > Crucially, Sensitive Record Exclusion only applies to records which the user does not have access to. If the user has access to a record, it will
@@ -104,5 +107,5 @@ npm start
 >
 > (E.g., `"tier_access_sensitive_record_exclusion_field": "sensitive"` in the Guppy config tells Guppy to look for a field in the ES index called `sensitive`, and to exclude records in the ES index which have `sensitive: "true"`)
 
-#### Download endpoint
+### Download Endpoint:
 Guppy has another special endpoint `/download` for just fetching raw data from elasticsearch. please see [here](https://github.com/uc-cdis/guppy/blob/master/doc/download.md) for more details.

--- a/devHelper/README.md
+++ b/devHelper/README.md
@@ -7,7 +7,16 @@ docker-compose -f ./esearch.yml up -d
 ```
 
 ## Step.2 import mock data into elasticsearch index
-Guppy has a helper function to generate mock data for a specific ES index. For example, to generate data for an ES index called `gen3-dev-subject` with document type `subject`, run the following command:
+Go to the repository's root directory and run the following command.
+
+```
+sh ./generate_data.sh
+```
+
+Doing so will automatically generate 3 ES indices (1 for `subject`, 1 for `file`, and 1 for `config`) and populate 100 records into each index.
+
+### Manually generate more mock data for a specific elasticsearch index (optional)
+In case we want more mock data, Guppy has a helper function to generate mock data for a specific ES index. For example, to generate data for an ES index called `gen3-dev-subject` with document type `subject`, run the following command:
 ```
 npm run gendata -- -i gen3-dev-subject -d subject
 ```

--- a/devHelper/README.md
+++ b/devHelper/README.md
@@ -29,10 +29,19 @@ Here is a complete list of arguments that `npm run gendata` would take
 | -p, --port `<port>`          | elasticsearch port                                     | 9200              |
 | -i, --index `<index>`        | elasticsearch index                                    | undefined         |
 | -d, --doc_type `<doc_type>`  | document type                                          | undefined         |
+| -c, --config_index `<config_index>`  | array config index                             | gen3-dev-config   |
 | -n, --number `<number>`      | number of documents to generate                        | 500               |
 | -r, --random                 | generate random number of document up to `number`      | false             |
 
 Also, there are some predefined values in `/genData/valueBank.json`.
+
+:information_source: **Special handling for generating mock data for array type fields**
+
+In Elasticsearch, arrays do not require a dedicated field datatype. In other words, when defining an ES fields in the mapping object, array fields have no difference than other regular fields in terms of syntax. But GQL does differ array from other data types.
+
+So in order to add an array field to mock data, we require that field to explicitly contains the word `array` in its field name. And it is also required to put some predefined values for that array field in `/genData/valueBank.json`.
+
+Doing so will ensure the array config index be updated with names of all the array fields in an ES index. If you have array fields in any of your ES index, then it is necessary to have a correct array config index in order to successfully generate corresponding GQL schemas and resolvers. To specify the name of the array config index, pass a `-c` or `--config_index` argument to the `npm run gendata` command. The default name of test array config index is `gen3-dev-config`.
 
 ## Step.3 start server for developing server side code
 In the root directory of this repo, run:

--- a/devHelper/README.md
+++ b/devHelper/README.md
@@ -1,7 +1,7 @@
 # How to generate mock data and start developing in your local 
 
 ## Step.1 start elasticsearch
-
+In this directory `(/devHelper)`, do:
 ```
 docker-compose -f ./esearch.yml up -d
 ```

--- a/devHelper/README.md
+++ b/devHelper/README.md
@@ -1,13 +1,13 @@
 # How to generate mock data and start developing in your local 
 
 ## Step.1 start elasticsearch
-In this directory `(/devHelper)`, do:
+Go to the repository's root directory, do:
 ```
-docker-compose -f ./esearch.yml up -d
+docker-compose -f ./devHelper/docker/esearch.yml up -d
 ```
 
 ## Step.2 import mock data into elasticsearch index
-Go to the repository's root directory and run the following command.
+In the root directory of this repo, run the following command:
 
 ```
 sh ./generate_data.sh
@@ -35,7 +35,7 @@ Here is a complete list of arguments that `npm run gendata` would take
 Also, there are some predefined values in `/genData/valueBank.json`.
 
 ## Step.3 start server for developing server side code
-Go to repo root directory, and run
+In the root directory of this repo, run:
 
 ```
 GUPPY_PORT=3000 INTERNAL_LOCAL_TEST=true npm start
@@ -45,11 +45,10 @@ The Guppy server will be hosted at [localhost:3000/graphql](http://localhost:300
 We use nodemon to start the server, so all code change will be hot applied to the running server in realtime. 
 
 ## Step.4 start storybook for developing front-end components
-Go to repo root directory, and run
+In the root directory of this repo, run:
 
 ```
 npm run storybook
 ```
 
 [Storybook](https://storybook.js.org/) will be hosted at [localhost:6006](http://localhost:6006). 
-

--- a/devHelper/README.md
+++ b/devHelper/README.md
@@ -7,11 +7,23 @@ docker-compose -f ./esearch.yml up -d
 ```
 
 ## Step.2 import mock data into elasticsearch index
-Go to the repository's root directory and run the following command.
+Guppy has a helper function to generate mock data for a specific ES index. For example, to generate data for an ES index called `gen3-dev-subject` with document type `subject`, run the following command:
+```
+npm run gendata -- -i gen3-dev-subject -d subject
+```
 
-```
-sh ./generate_data.sh
-```
+Here is a complete list of arguments that `npm run gendata` would take
+| argument                     | description                                            | default           |
+|------------------------------|--------------------------------------------------------|-------------------|
+| -v, --verbose                | verbose output                                         | false             |
+| -h, --hostname `<hostname>`  | elasticsearch hostname                                 | http://localhost  |
+| -p, --port `<port>`          | elasticsearch port                                     | 9200              |
+| -i, --index `<index>`        | elasticsearch index                                    | undefined         |
+| -d, --doc_type `<doc_type>`  | document type                                          | undefined         |
+| -n, --number `<number>`      | number of documents to generate                        | 500               |
+| -r, --random                 | generate random number of document up to `number`      | false             |
+
+Also, there are some predefined values in `/genData/valueBank.json`.
 
 ## Step.3 start server for developing server side code
 Go to repo root directory, and run

--- a/devHelper/docker/esearch.yml
+++ b/devHelper/docker/esearch.yml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
   # see https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-cli-run-prod-mode
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.7.0
     ports:
       - "9200:9200"
       - "9300:9300"

--- a/devHelper/scripts/commands.sh
+++ b/devHelper/scripts/commands.sh
@@ -93,7 +93,13 @@ curl -iv -X PUT "${ESHOST}/${indexName}" \
           "auth_resource_path": { "type": "keyword", "fields": { "analyzed": {"type": "text", "analyzer": "ngram_analyzer", "search_analyzer": "search_analyzer", "term_vector": "with_positions_offsets"} } },
           "file_count": { "type": "integer" },
           "whatever_lab_result_value": { "type": "float" },
-          "some_string_field": { "type": "keyword", "fields": { "analyzed": {"type": "text", "analyzer": "ngram_analyzer", "search_analyzer": "search_analyzer", "term_vector": "with_positions_offsets"} } },
+          "some_nested_array_field": {
+            "type": "nested",
+            "properties": {
+              "some_integer_inside_nested": { "type": "integer" },
+              "some_string_inside_nested": { "type": "keyword", "fields": { "analyzed": {"type": "text", "analyzer": "ngram_analyzer", "search_analyzer": "search_analyzer", "term_vector": "with_positions_offsets"} } }
+            }
+          },
           "some_integer_field": { "type": "integer" },
           "some_long_field": { "type": "long" },
           "sensitive": { "type": "keyword" }
@@ -133,7 +139,13 @@ curl -iv -X PUT "${ESHOST}/${configIndexName}" \
             "number_of_shards" : 1,
             "number_of_replicas" : 0
         }
-    }
+    },
+    "mappings": {
+      "_doc": {
+        "properties": {
+          "array": { "type": "keyword" }
+        }
+      }
     }
 }
 '

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -12,6 +12,7 @@ Table of Contents
    - [Basic Filter Unit](#filter-unit)
    - [Text Search Unit in Filter](#filter-search)
    - [Combined Filters](#filter-comb)
+   - [Nested Filter](#filter-nested)
 - [Some other queries and arguments](#other)
 
 <a name="query"></a>
@@ -398,7 +399,7 @@ Result:
 ### 4. Nested Aggregation
 :bangbang: **This section is for performing aggregations on document which contains nested fields. For information about Guppy supporting nested sub-aggregations such as terms aggregation and missing aggregation, please refer to [Sub-aggregations](#aggs-sub)**
 
-Guppy supports performing aggregations (both text and numeric aggregations) on nested fields.
+Guppy supports performing aggregations (both text and numeric aggregations) on nested fields. For information about using nested fields inside filters, see [Nested Filter](#filter-nested)
 > Suppose the ES index has a mapping as the following:
 >```
 >   "mappings": {
@@ -927,7 +928,7 @@ In future Guppy will support `SQL` like syntax for filter, like `
 {"filter": "(race = 'hispanic' OR race='asian') AND (file_count >= 15 AND file_count <= 75) AND project = 'Proj-1' AND gender = 'female'"}
 `.
 
-<a name="other"></a>
+<a name="filter-nested"></a>
 
 ### Nested filter
 Guppy now supports query on nested ElasticSearch schema. The way to query and filter the nested index is similar to the ES query.
@@ -971,6 +972,7 @@ Assuming that there is `File` node nested inside `subject`. The nested query wil
 ElasticSearch only support the nested filter on the level of document for returning data. It means that the filter `file_count >=15` and `file_count<=75` will return the whole document having a `file_count` in the range of `[15, 75]`.
 The returned data will not filter the nested `file_count`(s) that are out of that range for that document.
 
+<a name="other"></a>
 ## Some other queries and arguments 
 
 ### Mapping query

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -495,48 +495,7 @@ Result:
               }
             ]
           },
-          "days_to_visit": {
-            "histogram": [
-              {
-                "key": [
-                  1,
-                  2
-                ],
-                "count": 21
-              },
-              {
-                "key": [
-                  2,
-                  3
-                ],
-                "count": 19
-              },
-              {
-                "key": [
-                  3,
-                  4
-                ],
-                "count": 29
-              }
-            ]
-          },
           "follow_ups": {
-            "follow_up_label": {
-              "histogram": [
-                {
-                  "key": "flup_lbl_3",
-                  "count": 29
-                },
-                {
-                  "key": "flup_lbl_1",
-                  "count": 21
-                },
-                {
-                  "key": "flup_lbl_2",
-                  "count": 19
-                }
-              ]
-            },
             "days_to_follow_up": {
               "histogram": [
                 {

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -399,7 +399,7 @@ Result:
 ### 4. Nested Aggregation
 :bangbang: **This section is for performing aggregations on documents which contain nested fields. For information about Guppy supporting nested sub-aggregations such as terms aggregation and missing aggregation, please refer to [Sub-aggregations](#aggs-sub)**
 
->The difference between Nested Aggregations and Sub-aggregations is that Nested Aggregations are performed on multi-level nested fields, while the sub-aggregations are preformed on different fields within a same level.
+>The difference between Nested Aggregations and Sub-aggregations is that Nested Aggregations are performed on multi-level nested fields, while the sub-aggregations are performed on different fields within a same level.
 
 Guppy supports performing aggregations (both text and numeric aggregations) on nested fields. For information about using nested fields inside filters, see [Nested Filter](#filter-nested)
 > Suppose the ES index has a mapping as the following:

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -534,9 +534,26 @@ Result:
 <a name="aggs-sub"></a>
 
 ### 5. Sub-aggregations
+:warning: **This section is for performing sub-aggregations (terms and missing aggregations) on documents. This section was incorrectly named as "Nested Aggregation" before Guppy 0.5.0 and has been corrected since then.**
+
+>The difference between Nested Aggregations and Sub-aggregations is that Nested Aggregations are performed on multi-level nested fields, while the sub-aggregations are preformed on different fields within a same level.
+
 Guppy supports sub-aggregations for fields. Currently Guppy only supports two-level-sub-aggregations.
 
 There are two types of sub-aggregations that is supported by Guppy: terms aggregation and missing aggregation, user can mix-and-match the using of both aggregations.
+For more information about ES terms aggregation and missing aggregation, please read: [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) and [Missing Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-missing-aggregation.html)
+
+> For examples in the following sections, assume the ES index has a mapping as the following:
+>```
+>   "mappings": {
+>     "subject": {
+>       "properties": {
+>         "project": { "type": "keyword" },
+>         "gender": { "type": "keyword" },
+>         },
+>       }
+>    }
+>```
 
 #### 5.1. Terms Aggregation
 Terms aggregation requires a single `field` for parent aggregation and an array of fields for the nested sub-aggregations. The sub-aggregations will be computed for the buckets which their parent aggregation generates. It is intended to show for each of the `key` of the single `field` in the parent aggregation, what is the distribution of each element from the array of fields in the sub-aggregations.

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -399,6 +399,8 @@ Result:
 ### 4. Nested Aggregation
 :bangbang: **This section is for performing aggregations on documents which contain nested fields. For information about Guppy supporting nested sub-aggregations such as terms aggregation and missing aggregation, please refer to [Sub-aggregations](#aggs-sub)**
 
+>The difference between Nested Aggregations and Sub-aggregations is that Nested Aggregations are performed on multi-level nested fields, while the sub-aggregations are preformed on different fields within a same level.
+
 Guppy supports performing aggregations (both text and numeric aggregations) on nested fields. For information about using nested fields inside filters, see [Nested Filter](#filter-nested)
 > Suppose the ES index has a mapping as the following:
 >```
@@ -535,8 +537,6 @@ Result:
 
 ### 5. Sub-aggregations
 :warning: **This section is for performing sub-aggregations (terms and missing aggregations) on documents. This section was incorrectly named as "Nested Aggregation" before Guppy 0.5.0 and has been corrected since then.**
-
->The difference between Nested Aggregations and Sub-aggregations is that Nested Aggregations are performed on multi-level nested fields, while the sub-aggregations are preformed on different fields within a same level.
 
 Guppy supports sub-aggregations for fields. Currently Guppy only supports two-level-sub-aggregations.
 

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -397,7 +397,7 @@ Result:
 <a name="aggs-nested"></a>
 
 ### 4. Nested Aggregation
-:bangbang: **This section is for performing aggregations on document which contains nested fields. For information about Guppy supporting nested sub-aggregations such as terms aggregation and missing aggregation, please refer to [Sub-aggregations](#aggs-sub)**
+:bangbang: **This section is for performing aggregations on documents which contain nested fields. For information about Guppy supporting nested sub-aggregations such as terms aggregation and missing aggregation, please refer to [Sub-aggregations](#aggs-sub)**
 
 Guppy supports performing aggregations (both text and numeric aggregations) on nested fields. For information about using nested fields inside filters, see [Nested Filter](#filter-nested)
 > Suppose the ES index has a mapping as the following:
@@ -1226,4 +1226,3 @@ Result:
   }
 }
 ```
-

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -541,6 +541,7 @@ Result:
 Guppy supports sub-aggregations for fields. Currently Guppy only supports two-level-sub-aggregations.
 
 There are two types of sub-aggregations that is supported by Guppy: terms aggregation and missing aggregation, user can mix-and-match the using of both aggregations.
+
 For more information about ES terms aggregation and missing aggregation, please read: [Terms Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) and [Missing Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-missing-aggregation.html)
 
 > For examples in the following sections, assume the ES index has a mapping as the following:

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -396,7 +396,7 @@ Result:
 <a name="aggs-nested"></a>
 
 ### 4. Nested Aggregation
-:heavy_exclamation_mark: This section is for performing aggregations on document which contains nested fields. For information about Guppy supporting nested sub-aggregations such as terms aggregation and missing aggregation, please refer to [Sub-aggregations](#aggs-sub)
+:bangbang: **This section is for performing aggregations on document which contains nested fields. For information about Guppy supporting nested sub-aggregations such as terms aggregation and missing aggregation, please refer to [Sub-aggregations](#aggs-sub)**
 
 Guppy supports performing aggregations (both text and numeric aggregations) on nested fields.
 > Suppose the ES index has a mapping as the following:

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -425,12 +425,12 @@ Guppy supports performing aggregations (both text and numeric aggregations) on n
 >    }
 >```
 
-An example nested query that Guppy can perform with respect to that ESS index could be:
+An example nested query that Guppy can perform with respect to that ES index could be:
 ```
 query: {
   _aggregation: {
     subject: {
-      subject_id: {                    --> normal non-nested aggregation
+      subject_id: {                    --> regular non-nested aggregation
         histogram: {
           key
           count

--- a/genData/genData.js
+++ b/genData/genData.js
@@ -132,7 +132,7 @@ async function run() {
   chunks.forEach((c) => {
     client.bulk({ refresh: true, body: c }).then((res) => {
       res.body.items.forEach((item) => console.log(item));
-      console.log(`Successfully insert ${c.length / 2} items`);
+      console.log(`Successfully inserted ${c.length / 2} items`);
     }).catch((res) => {
       if (res.body.errors) {
         const erroredDocuments = [];

--- a/genData/genData.js
+++ b/genData/genData.js
@@ -96,7 +96,6 @@ async function run() {
         const index = getRandomInt(0, fieldValues[key].length - 1);
         dCopy[key] = fieldValues[key][index];
       } else {
-        console.log('vtype: ', schema.items.properties[key].rawType);
         switch (schema.items.properties[key].rawType) {
           case 'integer':
             dCopy[key] = getRandomInt(MIN_INT, MAX_INT);

--- a/genData/genData.js
+++ b/genData/genData.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 require('array.prototype.flatmap').shim();
 
 const program = require('commander');

--- a/genData/genData.js
+++ b/genData/genData.js
@@ -23,7 +23,7 @@ program.parse(process.argv);
 
 const esHost = `${program.hostname}:${program.port}`;
 const esIndex = program.index;
-const configIndex = program.config_index;
+const configIndex = program.config_index || 'gen3-dev-config';
 
 const client = new Client({ node: esHost });
 

--- a/genData/genData.js
+++ b/genData/genData.js
@@ -20,8 +20,6 @@ program
 
 program.parse(process.argv);
 
-// console.log(program);
-
 const esHost = `${program.hostname}:${program.port}`;
 const esIndex = program.index;
 
@@ -118,8 +116,6 @@ async function run() {
     });
     return dCopy;
   });
-
-  console.log('sample: ', sample);
 
   const body = sample.flatMap((d) => [{
     index: {

--- a/genData/types.js
+++ b/genData/types.js
@@ -12,6 +12,7 @@ function fakerType(value) {
     case 'text':
       fieldType = { type: 'string', faker: 'name.findName' };
       break;
+    case 'float':
     case 'double':
       fieldType = { type: 'number' };
       break;
@@ -32,7 +33,10 @@ function fakerType(value) {
       // console.log(value);
       break;
   }
-  return fieldType;
+  return {
+    ...fieldType,
+    rawType: value.type,
+  };
 }
 
 module.exports = {

--- a/genData/types.js
+++ b/genData/types.js
@@ -5,6 +5,7 @@ function fakerType(key, value, arrayFields) {
 
   switch (value.type) {
     case 'boolean':
+      // if a field is an array, say it explicit in the name, since ES does not know
       if (key.includes('array')) {
         fieldType = {
           type: 'array', items: { type: 'boolean', properties, required }, minItems: 0, maxItems: 10,

--- a/genData/types.js
+++ b/genData/types.js
@@ -1,33 +1,68 @@
-function fakerType(value) {
+function fakerType(key, value, arrayFields) {
   let fieldType;
   const properties = {};
   const required = [];
+
   switch (value.type) {
     case 'boolean':
-      fieldType = { type: 'boolean' };
+      if (key.includes('array')) {
+        fieldType = {
+          type: 'array', items: { type: 'boolean', properties, required }, minItems: 0, maxItems: 10,
+        };
+        arrayFields.push(key);
+      } else {
+        fieldType = { type: 'boolean' };
+      }
       break;
     case 'keyword':
-      fieldType = { type: 'string', faker: 'name.findName' };
-      break;
     case 'text':
-      fieldType = { type: 'string', faker: 'name.findName' };
+      if (key.includes('array')) {
+        fieldType = {
+          type: 'array',
+          items: {
+            type: 'string', faker: 'name.findName', properties, required,
+          },
+          minItems: 0,
+          maxItems: 10,
+        };
+        arrayFields.push(key);
+      } else {
+        fieldType = { type: 'string', faker: 'name.findName' };
+      }
       break;
     case 'float':
     case 'double':
-      fieldType = { type: 'number' };
+      if (key.includes('array')) {
+        fieldType = {
+          type: 'array', items: { type: 'number', properties, required }, minItems: 0, maxItems: 10,
+        };
+        arrayFields.push(key);
+      } else {
+        fieldType = { type: 'number' };
+      }
       break;
     case 'long':
     case 'integer':
-      fieldType = { type: 'integer' };
+      if (key.includes('array')) {
+        fieldType = {
+          type: 'array', items: { type: 'integer', properties, required }, minItems: 0, maxItems: 10,
+        };
+        arrayFields.push(key);
+      } else {
+        fieldType = { type: 'integer' };
+      }
       break;
     case 'nested':
-      Object.entries(value.properties).forEach(([key, v]) => {
-        properties[key] = fakerType(v);
-        required.push(key);
+      Object.entries(value.properties).forEach(([k, v]) => {
+        properties[k] = fakerType(k, v);
+        required.push(k);
       });
       fieldType = {
-        type: 'array', items: { type: 'object', properties, required }, minItems: 10, maxItems: 10,
+        type: 'array', items: { type: 'object', properties, required }, minItems: 0, maxItems: 10,
       };
+      if (key.includes('array')) {
+        arrayFields.push(key);
+      }
       break;
     default:
       // console.log(value);

--- a/genData/valueBank.json
+++ b/genData/valueBank.json
@@ -2,10 +2,39 @@
     "gender": ["male", "female", "unknown"],
     "ethnicity": ["American Indian", "Pacific Islander", "Black", "Multi-racial", "White", "Haspanic" ],
     "race": ["white", "black", "hispanic", "asian", "mixed", "not reported" ],
-    "vital": ["Alive", "Dead", "no data" ],
+    "vital_status": ["Alive", "Dead", "no data" ],
     "file_type": ["mRNA Array", "Unaligned Reads", "Lipdomic MS", "Protionic MS", "1Gs Ribosomes", "Unknown" ],
     "file_format": ["BEM", "BAM", "BED", "CSV", "FASTQ", "RAW", "TAR", "TSV", "TXT", "IDAT" ],
     "auth_resource_path": ["/programs/jnkns/projects/jenkins", "/programs/DEV/projects/test", "/programs/external/projects/test"],
     "sensitive": [ "true", "false" ],
-    "project": ["jnkns-jenkins", "DEV-test", "external-test" ]
+    "study": ["study_1", "study_2", "study_3"],
+    "file_id": ["file_id_1", "file_id_2", "file_id_3"],
+    "subject_id": ["subject_id_1", "subject_id_2", "subject_id_3"],
+    "project": ["jnkns-jenkins", "DEV-test", "external-test" ],
+    "visits": [
+        {
+            "days_to_visit": 1,
+            "visit_label": "vst_lbl_1",
+            "follow_ups": {
+                "days_to_follow_up": 1,
+                "follow_up_label": "flup_lbl_1"
+            }
+        },
+        {
+            "days_to_visit": 2,
+            "visit_label": "vst_lbl_2",
+            "follow_ups": {
+                "days_to_follow_up": 2,
+                "follow_up_label": "flup_lbl_2"
+            }
+        },
+        {
+            "days_to_visit": 3,
+            "visit_label": "vst_lbl_3",
+            "follow_ups": {
+                "days_to_follow_up": 3,
+                "follow_up_label": "flup_lbl_3"
+            }
+        }
+    ]
 }

--- a/genData/valueBank.json
+++ b/genData/valueBank.json
@@ -36,5 +36,37 @@
                 "follow_up_label": "flup_lbl_3"
             }
         }
+    ],
+    "some_nested_array_field": [
+        [
+            {
+              "some_integer_inside_nested": 1,
+              "some_string_inside_nested": "first"
+            },
+            {
+                "some_integer_inside_nested": 2,
+                "some_string_inside_nested": "second"
+              }
+        ],
+        [
+            {
+              "some_integer_inside_nested": 3,
+              "some_string_inside_nested": "third"
+            },
+            {
+                "some_integer_inside_nested": 4,
+                "some_string_inside_nested": "forth"
+              }
+        ],
+        [
+            {
+              "some_integer_inside_nested": 5,
+              "some_string_inside_nested": "fifth"
+            },
+            {
+                "some_integer_inside_nested": 6,
+                "some_string_inside_nested": "sixth"
+              }
+        ]
     ]
 }

--- a/generate_data.sh
+++ b/generate_data.sh
@@ -14,4 +14,4 @@ npm run gendata -- -i $SUBJECT_INDEX_NAME -d subject -n $DATA_COUNT
 npm run gendata -- -i $FILE_INDEX_NAME -d file -n $DATA_COUNT
 npm run gendata -- -i $CONFIG_INDEX_NAME -d config -n $DATA_COUNT
 
-echo "Successfully generate ${DATA_COUNT} data records"
+echo "Successfully generated ${DATA_COUNT} data records"

--- a/generate_data.sh
+++ b/generate_data.sh
@@ -10,8 +10,7 @@ es_delete_all $SUBJECT_INDEX_NAME
 es_delete_all $FILE_INDEX_NAME
 es_delete_all $CONFIG_INDEX_NAME
 es_setup_index $SUBJECT_INDEX_NAME $FILE_INDEX_NAME $CONFIG_INDEX_NAME
-npm run gendata -- -i $SUBJECT_INDEX_NAME -d subject -n $DATA_COUNT
-npm run gendata -- -i $FILE_INDEX_NAME -d file -n $DATA_COUNT
-npm run gendata -- -i $CONFIG_INDEX_NAME -d config -n $DATA_COUNT
+npm run gendata -- -i $SUBJECT_INDEX_NAME -d subject -n $DATA_COUNT -c $CONFIG_INDEX_NAME
+npm run gendata -- -i $FILE_INDEX_NAME -d file -n $DATA_COUNT -c $CONFIG_INDEX_NAME
 
 echo "Successfully generated ${DATA_COUNT} data records"

--- a/generate_data.sh
+++ b/generate_data.sh
@@ -2,15 +2,15 @@
 
 source ./devHelper/scripts/commands.sh
 
-CASE_INDEX_NAME=gen3-dev-subject
+SUBJECT_INDEX_NAME=gen3-dev-subject
 FILE_INDEX_NAME=gen3-dev-file
 CONFIG_INDEX_NAME=gen3-dev-config
 DATA_COUNT=100
-es_delete_all $CASE_INDEX_NAME
+es_delete_all $SUBJECT_INDEX_NAME
 es_delete_all $FILE_INDEX_NAME
 es_delete_all $CONFIG_INDEX_NAME
-es_setup_index $CASE_INDEX_NAME $FILE_INDEX_NAME $CONFIG_INDEX_NAME
-npm run gendata -- -i $CASE_INDEX_NAME -d subject -n $DATA_COUNT
+es_setup_index $SUBJECT_INDEX_NAME $FILE_INDEX_NAME $CONFIG_INDEX_NAME
+npm run gendata -- -i $SUBJECT_INDEX_NAME -d subject -n $DATA_COUNT
 npm run gendata -- -i $FILE_INDEX_NAME -d file -n $DATA_COUNT
 npm run gendata -- -i $CONFIG_INDEX_NAME -d config -n $DATA_COUNT
 

--- a/generate_data.sh
+++ b/generate_data.sh
@@ -10,8 +10,8 @@ es_delete_all $CASE_INDEX_NAME
 es_delete_all $FILE_INDEX_NAME
 es_delete_all $CONFIG_INDEX_NAME
 es_setup_index $CASE_INDEX_NAME $FILE_INDEX_NAME $CONFIG_INDEX_NAME
-npm run gendata -- -i $CASE_INDEX_NAME -d subject
-npm run gendata -- -i $FILE_INDEX_NAME -d file
-npm run gendata -- -i $CONFIG_INDEX_NAME -d config
+npm run gendata -- -i $CASE_INDEX_NAME -d subject -n $DATA_COUNT
+npm run gendata -- -i $FILE_INDEX_NAME -d file -n $DATA_COUNT
+npm run gendata -- -i $CONFIG_INDEX_NAME -d config -n $DATA_COUNT
 
-echo "successfully generate ${DATA_COUNT} data records"
+echo "Successfully generate ${DATA_COUNT} data records"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4008,7 +4008,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz",
       "integrity": "sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "apollo-server": "^2.4.8",
     "apollo-server-express": "^2.4.8",
     "array.prototype.flat": "^1.2.2",
+    "array.prototype.flatmap": "^1.2.3",
     "body-parser": "^1.18.3",
     "cors": "^2.8.5",
     "express": "^4.16.4",

--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -4,7 +4,7 @@ import mockTextAggs from './mockESData/mockTextAggs';
 import mockNumericAggsGlobalStats from './mockESData/mockNumericAggsGlobalStats';
 import mockHistogramFixWidth from './mockESData/mockNumericHistogramFixWidth';
 import mockHistogramFixBinCount from './mockESData/mockNumericHistogramFixBinCount';
-import mockNestedAggs from './mockESData/mockNestedAggs';
+import mockNestedTermsAndMissingAggs from './mockESData/mockNestedTermsAndMissingAggs';
 
 const mockPing = () => {
   nock(config.esConfig.host)
@@ -350,7 +350,7 @@ const setup = () => {
   mockNumericAggsGlobalStats();
   mockHistogramFixWidth();
   mockHistogramFixBinCount();
-  mockNestedAggs();
+  mockNestedTermsAndMissingAggs();
 };
 
 export default setup;

--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -5,6 +5,7 @@ import mockNumericAggsGlobalStats from './mockESData/mockNumericAggsGlobalStats'
 import mockHistogramFixWidth from './mockESData/mockNumericHistogramFixWidth';
 import mockHistogramFixBinCount from './mockESData/mockNumericHistogramFixBinCount';
 import mockNestedTermsAndMissingAggs from './mockESData/mockNestedTermsAndMissingAggs';
+import mockNestedAggs from './mockESData/mockNestedAggs';
 
 const mockPing = () => {
   nock(config.esConfig.host)
@@ -351,6 +352,7 @@ const setup = () => {
   mockHistogramFixWidth();
   mockHistogramFixBinCount();
   mockNestedTermsAndMissingAggs();
+  mockNestedAggs();
 };
 
 export default setup;

--- a/src/server/__mocks__/mockESData/mockNestedAggs.js
+++ b/src/server/__mocks__/mockESData/mockNestedAggs.js
@@ -1,0 +1,191 @@
+import mockSearchEndpoint from './utils';
+
+const mockNestedAggs = () => {
+  // one-level text
+  const nestedAggsQuery1 = {
+    size: 0,
+    aggs: {
+      visit_labelNestedAggs: {
+        nested: {
+          path: 'visits',
+        },
+        aggs: {
+          visit_labelAggs: {
+            composite: {
+              sources: [
+                {
+                  'visits.visit_label': {
+                    terms: {
+                      field: 'visits.visit_label',
+                      missing: 'no data',
+                    },
+                  },
+                },
+              ],
+              size: 10000,
+            },
+          },
+        },
+      },
+    },
+  };
+  const fakeNestedAggs1 = {
+    aggregations: {
+      visit_labelNestedAggs: {
+        doc_count: 69,
+        visit_labelAggs: {
+          after_key: {
+            'visits.visit_label': 'vst_lbl_3',
+          },
+          buckets: [
+            {
+              key: {
+                'visits.visit_label': 'vst_lbl_1',
+              },
+              doc_count: 21,
+            },
+            {
+              key: {
+                'visits.visit_label': 'vst_lbl_2',
+              },
+              doc_count: 19,
+            },
+            {
+              key: {
+                'visits.visit_label': 'vst_lbl_3',
+              },
+              doc_count: 29,
+            },
+            {
+              key: {
+                'visits.visit_label': 'no data',
+              },
+              doc_count: 40,
+            },
+          ],
+        },
+      },
+    },
+  };
+  mockSearchEndpoint(nestedAggsQuery1, fakeNestedAggs1);
+
+  // two-level numeric global stats
+  const nestedAggsQuery2 = {
+    size: 0,
+    aggs: {
+      numeric_nested_aggs: {
+        nested: {
+          path: 'visits.follow_ups',
+        },
+        aggs: {
+          numeric_aggs_stats: {
+            stats: {
+              field: 'visits.follow_ups.days_to_follow_up',
+            },
+          },
+        },
+      },
+    },
+  };
+  const fakeNestedAggs2 = {
+    aggregations: {
+      numeric_nested_aggs: {
+        doc_count: 69,
+        numeric_aggs_stats: {
+          count: 69,
+          min: 1.0,
+          max: 3.0,
+          avg: 2.1159420289855073,
+          sum: 146.0,
+        },
+      },
+    },
+  };
+  mockSearchEndpoint(nestedAggsQuery2, fakeNestedAggs2);
+
+  // two-level numeric fixed bin width
+  const nestedAggsQuery3 = {
+    size: 0,
+    aggs: {
+      numeric_nested_aggs: {
+        nested: {
+          path: 'visits.follow_ups',
+        },
+        aggs: {
+          numeric_aggs_stats: {
+            stats: {
+              field: 'visits.follow_ups.days_to_follow_up',
+            },
+          },
+          numeric_aggs: {
+            histogram: {
+              field: 'visits.follow_ups.days_to_follow_up',
+              interval: 1,
+            },
+            aggs: {
+              numeric_item_aggs_stats: {
+                stats: {
+                  field: 'visits.follow_ups.days_to_follow_up',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  const fakeNestedAggs3 = {
+    aggregations: {
+      numeric_nested_aggs: {
+        doc_count: 69,
+        numeric_aggs: {
+          buckets: [
+            {
+              key: 1.0,
+              doc_count: 21,
+              numeric_item_aggs_stats: {
+                count: 21,
+                min: 1.0,
+                max: 1.0,
+                avg: 1.0,
+                sum: 21.0,
+              },
+            },
+            {
+              key: 2.0,
+              doc_count: 19,
+              numeric_item_aggs_stats: {
+                count: 19,
+                min: 2.0,
+                max: 2.0,
+                avg: 2.0,
+                sum: 38.0,
+              },
+            },
+            {
+              key: 3.0,
+              doc_count: 29,
+              numeric_item_aggs_stats: {
+                count: 29,
+                min: 3.0,
+                max: 3.0,
+                avg: 3.0,
+                sum: 87.0,
+              },
+            },
+          ],
+        },
+        numeric_aggs_stats: {
+          count: 69,
+          min: 1.0,
+          max: 3.0,
+          avg: 2.1159420289855073,
+          sum: 146.0,
+        },
+      },
+    },
+  };
+  mockSearchEndpoint(nestedAggsQuery3, fakeNestedAggs3);
+};
+
+export default mockNestedAggs;

--- a/src/server/__mocks__/mockESData/mockNestedTermsAndMissingAggs.js
+++ b/src/server/__mocks__/mockESData/mockNestedTermsAndMissingAggs.js
@@ -1,6 +1,6 @@
 import mockSearchEndpoint from './utils';
 
-const mockNestedAggs = () => {
+const mockNestedTermsAndMissingAggs = () => {
   // only missing fields in nestedAggFields variables
   const missingAggsQuery = {
     size: 0,
@@ -290,4 +290,4 @@ const mockNestedAggs = () => {
   mockSearchEndpoint(combinedAggsQuery, combinedTermsAggs);
 };
 
-export default mockNestedAggs;
+export default mockNestedTermsAndMissingAggs;

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -52,7 +52,7 @@ describe('Schema', () => {
   const expectedTypesSchemas = `
     type Subject {
       gen3_resource_path: String,
-      visits:[visits],
+      visits:[NestedVisits],
       gender: String,
       file_count: Int,
       name: String,
@@ -61,12 +61,12 @@ describe('Schema', () => {
       whatever_lab_result_value: Float,
       _matched:[MatchedItem]
     }
-    type visits {
+    type NestedVisits {
       days_to_visit:Int,
       visit_label:String,
-      follow_ups:[follow_ups],
+      follow_ups:[NestedFollow_ups],
     }
-    type follow_ups {
+    type NestedFollow_ups {
       days_to_follow_up:Int,
       follow_up_label:String,
     }
@@ -115,6 +115,7 @@ describe('Schema', () => {
       some_array_integer_field: HistogramForNumber,
       some_array_string_field: HistogramForString,
       whatever_lab_result_value: HistogramForNumber,
+      visits:NestedHistogramForVisits
     }
     type FileAggregation {
       _totalCount: Int

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -52,7 +52,7 @@ describe('Schema', () => {
   const expectedTypesSchemas = `
     type Subject {
       gen3_resource_path: String,
-      visits:[NestedVisits],
+      visits:visits,
       gender: String,
       file_count: Int,
       name: String,
@@ -61,12 +61,12 @@ describe('Schema', () => {
       whatever_lab_result_value: Float,
       _matched:[MatchedItem]
     }
-    type NestedVisits {
+    type visits {
       days_to_visit:Int,
       visit_label:String,
-      follow_ups:[NestedFollow_ups],
+      follow_ups:follow_ups,
     }
-    type NestedFollow_ups {
+    type follow_ups {
       days_to_follow_up:Int,
       follow_up_label:String,
     }

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -21,7 +21,7 @@ const config = {
         type: 'file',
       },
     ],
-    configIndex: inputConfig.config_index,
+    configIndex: inputConfig.config_index || 'gen3-dev-config',
     authFilterField: inputConfig.auth_filter_field || 'auth_resource_path',
     aggregationIncludeMissingData: typeof inputConfig.aggs_include_missing_data === 'undefined' ? true : inputConfig.aggs_include_missing_data,
     missingDataAlias: inputConfig.missing_data_alias || 'no data',

--- a/src/server/es/__tests__/aggs.test.js
+++ b/src/server/es/__tests__/aggs.test.js
@@ -863,7 +863,7 @@ describe('could aggregate for numeric fields, fixed bin count', () => {
   });
 });
 
-// see /src/server/__mocks__/mockESData/mockNestedAggs.js for mock results
+// see /src/server/__mocks__/mockESData/mockNestedTermsAndMissingAggs.js for mock results
 describe('could only aggregate to find missing fields (both existing and non-existing fields)', () => {
   test('nested missing-only aggregation', async () => {
     await esInstance.initialize();

--- a/src/server/es/__tests__/aggs.test.js
+++ b/src/server/es/__tests__/aggs.test.js
@@ -1099,3 +1099,103 @@ describe('could only aggregate to find missing fields (both existing and non-exi
     expect(result).toEqual(expectedResults);
   });
 });
+
+// see /src/server/__mocks__/mockESData/mockNestedAggs.js for mock results
+describe('could aggregate for one-level nested text fields', () => {
+  test('one-level nested text aggregation', async () => {
+    await esInstance.initialize();
+    const field = 'visit_label';
+    const nestedPath = 'visits';
+    const result = await textAggregation(
+      { esInstance, esIndex, esType },
+      { field, nestedPath },
+    );
+    const expectedResults = [
+      {
+        key: 'vst_lbl_3',
+        count: 29,
+      },
+      {
+        key: 'vst_lbl_1',
+        count: 21,
+      },
+      {
+        key: 'vst_lbl_2',
+        count: 19,
+      },
+      {
+        key: 'no data',
+        count: 40,
+      }, // missing data always at end
+    ];
+    expect(result).toEqual(expectedResults);
+  });
+
+  test('two-level nested numeric aggregation -- global stats', async () => {
+    await esInstance.initialize();
+    const field = 'days_to_follow_up';
+    const nestedPath = 'visits.follow_ups';
+    const result = await numericGlobalStats(
+      { esInstance, esIndex, esType },
+      { field, nestedPath },
+    );
+    const expectedResults = {
+      key: [
+        1,
+        3,
+      ],
+      count: 69,
+      min: 1.0,
+      max: 3.0,
+      avg: 2.1159420289855073,
+      sum: 146.0,
+    };
+    expect(result).toEqual(expectedResults);
+  });
+
+  test('two-level nested numeric aggregation -- fixed bin width', async () => {
+    await esInstance.initialize();
+    const field = 'days_to_follow_up';
+    const nestedPath = 'visits.follow_ups';
+    const result = await numericHistogramWithFixedRangeStep(
+      { esInstance, esIndex, esType },
+      { field, rangeStep: 1, nestedPath },
+    );
+    const expectedResults = [
+      {
+        key: [
+          1,
+          2,
+        ],
+        count: 21,
+        max: 1,
+        min: 1,
+        sum: 21,
+        avg: 1,
+      },
+      {
+        key: [
+          2,
+          3,
+        ],
+        count: 19,
+        max: 2,
+        min: 2,
+        sum: 38,
+        avg: 2,
+      },
+      {
+        key: [
+          3,
+          4,
+        ],
+        count: 29,
+        max: 3,
+        min: 3,
+        sum: 87,
+        avg: 3,
+      },
+    ];
+    expect(result).toEqual(expectedResults);
+  });
+});

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -134,6 +134,9 @@ export const appendAdditionalRangeQuery = (field, oldQuery, rangeStart, rangeEnd
  * @param {object} param1.filterSelf - only valid if to avoid filtering the same aggregation field
  * @param {object} param1.defaultAuthFilter - once param1.filter is empty,
  *                                            use this auth related filter instead
+ * @param {object} param1.nestedAggFields - fields for sub-aggregations
+ *                                          (terms and/or missing aggregation)
+ * @param {object} param1.nestedPath - path info used by nested aggregation
  * @returns {min, max, sum, count, avg, key}
  */
 export const numericGlobalStats = async (
@@ -216,6 +219,9 @@ export const numericGlobalStats = async (
  * @param {object} param1.filterSelf - only valid if to avoid filtering the same aggregation field
  * @param {object} param1.defaultAuthFilter - once param1.filter is empty,
  *                                            use this auth related filter instead
+ * @param {object} param1.nestedAggFields - fields for sub-aggregations
+ *                                          (terms and/or missing aggregation)
+ * @param {object} param1.nestedPath - path info used by nested aggregation
  */
 export const numericHistogramWithFixedRangeStep = async (
   {
@@ -332,6 +338,9 @@ export const numericHistogramWithFixedRangeStep = async (
  * @param {object} param1.filterSelf - only valid if to avoid filtering the same aggregation field
  * @param {object} param1.defaultAuthFilter - once param1.filter is empty,
  *                                            use this auth related filter instead
+ * @param {object} param1.nestedAggFields - fields for sub-aggregations
+ *                                          (terms and/or missing aggregation)
+ * @param {object} param1.nestedPath - path info used by nested aggregation
  */
 export const numericHistogramWithFixedBinCount = async (
   {
@@ -404,6 +413,9 @@ export const numericHistogramWithFixedBinCount = async (
  * @param {object} param1.filterSelf - only valid if to avoid filtering the same aggregation field
  * @param {object} param1.defaultAuthFilter - once param1.filter is empty,
  *                                            use this auth related filter instead
+ * @param {object} param1.nestedAggFields - fields for sub-aggregations
+ *                                          (terms and/or missing aggregation)
+ * @param {object} param1.nestedPath - path info used by nested aggregation
  */
 export const numericAggregation = async (
   {
@@ -507,6 +519,9 @@ export const numericAggregation = async (
  * @param {object} param1.filterSelf - only valid if to avoid filtering the same aggregation field
  * @param {object} param1.defaultAuthFilter - once param1.filter is empty,
  *                                            use this auth related filter instead
+ * @param {object} param1.nestedAggFields - fields for sub-aggregations
+ *                                          (terms and/or missing aggregation)
+ * @param {object} param1.nestedPath - path info used by nested aggregation
  */
 export const textAggregation = async (
   {
@@ -558,6 +573,7 @@ export const textAggregation = async (
     aggsObj.aggs = updateAggObjectForMissingFields(nestedAggFields.missingFields, aggsObj.aggs);
   }
 
+  // build up ES query if is nested aggregation
   if (aggsNestedName) {
     queryBody.aggs = {
       [aggsNestedName]: {
@@ -604,11 +620,11 @@ export const textAggregation = async (
       },
     };
   }
-  // log.debug('[textAggregation] queryBody', queryBody);
   let resultSize;
   let finalResults = [];
   /* eslint-disable */
   do {
+    // parse ES query result based on whether is doing nested aggregation or not (if `aggsNestedName` is defined)
     const result = await esInstance.query(esIndex, esType, queryBody); 
     resultSize = 0;
 

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -536,6 +536,7 @@ export const textAggregation = async (
     defaultAuthFilter,
     nestedAggFields,
     nestedPath,
+    numericField,
   },
 ) => {
   const queryBody = { size: 0 };
@@ -551,7 +552,9 @@ export const textAggregation = async (
   }
 
   let missingAlias = {};
-  if (config.esConfig.aggregationIncludeMissingData) {
+  // don't add missing alias to numeric field by default
+  // since the value of missing alias is a string
+  if (config.esConfig.aggregationIncludeMissingData && !numericField) {
     missingAlias = { missing: config.esConfig.missingDataAlias };
   }
   const aggsName = `${field}Aggs`;

--- a/src/server/es/aggs.js
+++ b/src/server/es/aggs.js
@@ -536,7 +536,7 @@ export const textAggregation = async (
     defaultAuthFilter,
     nestedAggFields,
     nestedPath,
-    numericField,
+    isNumericField,
   },
 ) => {
   const queryBody = { size: 0 };
@@ -554,7 +554,7 @@ export const textAggregation = async (
   let missingAlias = {};
   // don't add missing alias to numeric field by default
   // since the value of missing alias is a string
-  if (config.esConfig.aggregationIncludeMissingData && !numericField) {
+  if (config.esConfig.aggregationIncludeMissingData && !isNumericField) {
     missingAlias = { missing: config.esConfig.missingDataAlias };
   }
   const aggsName = `${field}Aggs`;

--- a/src/server/es/const.js
+++ b/src/server/es/const.js
@@ -1,4 +1,5 @@
 export const AGGS_QUERY_NAME = 'numeric_aggs';
+export const AGGS_NESTED_QUERY_NAME = 'numeric_nested_aggs';
 export const AGGS_GLOBAL_STATS_NAME = 'numeric_aggs_stats';
 export const AGGS_ITEM_STATS_NAME = 'numeric_item_aggs_stats';
 

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -446,6 +446,7 @@ class ES {
     filterSelf,
     defaultAuthFilter,
     nestedAggFields,
+    nestedPath,
   }) {
     return esAggregator.textAggregation(
       {
@@ -459,6 +460,7 @@ class ES {
         filterSelf,
         defaultAuthFilter,
         nestedAggFields,
+        nestedPath,
       },
     );
   }

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -448,6 +448,7 @@ class ES {
     defaultAuthFilter,
     nestedAggFields,
     nestedPath,
+    numericField,
   }) {
     return esAggregator.textAggregation(
       {
@@ -462,6 +463,7 @@ class ES {
         defaultAuthFilter,
         nestedAggFields,
         nestedPath,
+        numericField,
       },
     );
   }

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -329,7 +329,6 @@ class ES {
     const queryBody = { from: offset };
     if (typeof filter !== 'undefined') {
       queryBody.query = getFilterObj(this, esIndex, filter);
-      log.debug('[ES] filterObj: ', queryBody.query);
     }
     queryBody.sort = getESSortBody(sort, this, esIndex);
     if (typeof size !== 'undefined') {

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -448,7 +448,7 @@ class ES {
     defaultAuthFilter,
     nestedAggFields,
     nestedPath,
-    numericField,
+    isNumericField,
   }) {
     return esAggregator.textAggregation(
       {
@@ -463,7 +463,7 @@ class ES {
         defaultAuthFilter,
         nestedAggFields,
         nestedPath,
-        numericField,
+        isNumericField,
       },
     );
   }

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -287,7 +287,7 @@ class ES {
           if (value.type !== 'nested') {
             r = { name: key, type: value.type };
           } else {
-            r = buildNestedField(key, value, r);
+            r = buildNestedField(key, value);
           }
           return r;
         }),

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -415,6 +415,7 @@ class ES {
     filterSelf,
     defaultAuthFilter,
     nestedAggFields,
+    nestedPath,
   }) {
     return esAggregator.numericAggregation(
       {
@@ -434,6 +435,7 @@ class ES {
         filterSelf,
         defaultAuthFilter,
         nestedAggFields,
+        nestedPath,
       },
     );
   }

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -102,9 +102,10 @@ const textHistogramResolver = async (parent, args, context) => {
   log.debug('[resolver.textHistogramResolver] args', args);
   const {
     esInstance, esIndex, esType,
-    filter, field, nestedAggFields, filterSelf, accessibility,
+    filter, field, nestedAggFields, filterSelf, accessibility, nestedPath,
   } = parent;
-  log.debug('[resolver.textHistogramResolver] parent', parent);
+  // log.debug('[resolver.textHistogramResolver] parent', parent);
+  log.debug('[resolver.textHistogramResolver] nestedPath', nestedPath);
   const { authHelper } = context;
   const defaultAuthFilter = await authHelper.getDefaultFilter(accessibility);
   return esInstance.textAggregation({
@@ -115,6 +116,7 @@ const textHistogramResolver = async (parent, args, context) => {
     filterSelf,
     defaultAuthFilter,
     nestedAggFields,
+    nestedPath,
   });
 };
 
@@ -122,7 +124,7 @@ const getFieldAggregationResolverMappingsByField = (field) => {
   if (field.type !== 'nested') {
     return ((parent) => ({ ...parent, field: field.name }));
   }
-  return ((parent) => ({ ...parent, field: field.name, path: (parent.path) ? `${parent.path}.${field.name}` : `${field.name}` }));
+  return ((parent) => ({ ...parent, field: field.name, nestedPath: (parent.nestedPath) ? `${parent.nestedPath}.${field.name}` : `${field.name}` }));
 };
 
 const getFieldAggregationResolverMappings = (esInstance, esIndex) => {
@@ -197,11 +199,11 @@ const getResolver = (esConfig, esInstance) => {
   const typeNestedAggregationResolvers = esConfig.indices.reduce((acc, cfg) => {
     const { fields } = esInstance.getESFields(cfg.index);
     const nestedFieldsArray = fields.filter((entry) => entry.type === 'nested');
-    log.debug('[resolver.typeNestedAggregationResolvers] nestedFieldsArray', nestedFieldsArray);
+    // log.debug('[resolver.typeNestedAggregationResolvers] nestedFieldsArray', nestedFieldsArray);
 
     while (nestedFieldsArray.length > 0) {
       const nestedFields = nestedFieldsArray.shift();
-      log.debug('[resolver.typeNestedAggregationResolvers] nestedFields', nestedFields);
+      // log.debug('[resolver.typeNestedAggregationResolvers] nestedFields', nestedFields);
       const typeNestedAggsName = `NestedHistogramFor${firstLetterUpperCase(nestedFields.name)}`;
       acc[typeNestedAggsName] = {};
       if (nestedFields.type === 'nested' && nestedFields.nestedProps) {

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -65,7 +65,7 @@ const aggsTotalQueryResolver = (parent) => {
 const numericHistogramResolver = async (parent, args, context) => {
   const {
     esInstance, esIndex, esType,
-    filter, field, nestedAggFields, filterSelf, accessibility,
+    filter, field, nestedAggFields, filterSelf, accessibility, nestedPath,
   } = parent;
   log.debug('[resolver.numericHistogramResolver] parent', parent);
   const {
@@ -87,6 +87,7 @@ const numericHistogramResolver = async (parent, args, context) => {
     filterSelf,
     defaultAuthFilter,
     nestedAggFields,
+    nestedPath,
   });
 };
 
@@ -104,8 +105,7 @@ const textHistogramResolver = async (parent, args, context) => {
     esInstance, esIndex, esType,
     filter, field, nestedAggFields, filterSelf, accessibility, nestedPath,
   } = parent;
-  // log.debug('[resolver.textHistogramResolver] parent', parent);
-  log.debug('[resolver.textHistogramResolver] nestedPath', nestedPath);
+  log.debug('[resolver.textHistogramResolver] parent', parent);
   const { authHelper } = context;
   const defaultAuthFilter = await authHelper.getDefaultFilter(accessibility);
   return esInstance.textAggregation({

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -104,7 +104,7 @@ const textHistogramResolver = async (parent, args, context) => {
   log.debug('[resolver.textHistogramResolver] args', args);
   const {
     esInstance, esIndex, esType,
-    filter, field, nestedAggFields, filterSelf, accessibility, nestedPath, numericField,
+    filter, field, nestedAggFields, filterSelf, accessibility, nestedPath, isNumericField,
   } = parent;
   log.debug('[resolver.textHistogramResolver] parent', parent);
   const { authHelper } = context;
@@ -118,21 +118,21 @@ const textHistogramResolver = async (parent, args, context) => {
     defaultAuthFilter,
     nestedAggFields,
     nestedPath,
-    numericField,
+    isNumericField,
   });
 };
 
 const getFieldAggregationResolverMappingsByField = (field) => {
-  let numericField = false;
+  let isNumericField = false;
   if (esFieldNumericTextTypeMapping[field.type] === NumericTextTypeTypeEnum.ES_NUMERIC_TYPE) {
-    numericField = true;
+    isNumericField = true;
   }
   if (field.type !== 'nested') {
-    return ((parent) => ({ ...parent, field: field.name, numericField }));
+    return ((parent) => ({ ...parent, field: field.name, isNumericField }));
   }
   // if field is nested type, update nestedPath info with parent's nestedPath and pass down
   return ((parent) => ({
-    ...parent, field: field.name, nestedPath: (parent.nestedPath) ? `${parent.nestedPath}.${field.name}` : `${field.name}`, numericField,
+    ...parent, field: field.name, nestedPath: (parent.nestedPath) ? `${parent.nestedPath}.${field.name}` : `${field.name}`, isNumericField,
   }));
 };
 

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -122,9 +122,9 @@ const getFieldAggregationResolverMappings = (esInstance, esIndex) => {
   const fieldAggregationResolverMappings = {};
   const { fields } = esInstance.getESFields(esIndex);
   fields.forEach((field) => {
-    if (field.type !== 'nested') {
-      fieldAggregationResolverMappings[`${field.name}`] = ((parent) => ({ ...parent, field: field.name }));
-    }
+    // if (field.type !== 'nested') {
+    fieldAggregationResolverMappings[`${field.name}`] = ((parent) => ({ ...parent, field: field.name }));
+    // }
   });
   return fieldAggregationResolverMappings;
 };

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -179,6 +179,11 @@ export const getAggregationSchema = (esConfig) => `
     }
   `;
 
+/**
+ * This is the function for getting schemas for a single nested index.
+ * Multi-level nested fields are "flattened" level by level.
+ * For each level of nested field a new type in schema is created.
+ */
 const getAggregationSchemaForOneNestedIndex = (esInstance, esIndex) => {
   const fieldGQLTypeMap = getFieldGQLTypeMapForOneIndex(esInstance, esIndex);
   const fieldAggsNestedTypeMap = fieldGQLTypeMap.filter((f) => f.esType === 'nested');

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -27,7 +27,7 @@ const getGQLType = (esInstance, esIndex, field, esFieldType) => {
     return `[${gqlType}]`;
   }
   if (esFieldType === 'nested') {
-    return `[Nested${firstLetterUpperCase(field)}]`;
+    return `${field}`;
   }
   return gqlType;
 };
@@ -104,7 +104,7 @@ const getTypeSchemaForOneIndex = (esInstance, esIndex, esType) => {
     const esFieldType = fieldESTypeMap[fieldKey].type;
     if (esFieldType === 'nested' && !existingFields.has(fieldKey)) {
       const { properties } = fieldESTypeMap[fieldKey];
-      queueTypes.push({ type: `Nested${firstLetterUpperCase(fieldKey)}`, properties });
+      queueTypes.push({ type: `${fieldKey}`, properties });
       existingFields.add(fieldKey);
     }
   });
@@ -121,7 +121,7 @@ const getTypeSchemaForOneIndex = (esInstance, esIndex, esType) => {
     const gqlTypes = getFieldGQLTypeMapForProperties(esInstance, esIndex, t.properties);
     gqlTypes.forEach((entry) => {
       if (entry.esType === 'nested' && !existingFields.has(entry.field)) {
-        queueTypes.push({ type: `Nested${firstLetterUpperCase(entry.field)}`, properties: entry.properties });
+        queueTypes.push({ type: `${entry.field}`, properties: entry.properties });
         existingFields.add(entry.field);
         fieldToArgs[entry.field] = getArgsByField(entry.field, entry.properties);
       }

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -200,8 +200,7 @@ const getAggregationSchemaForOneNestedIndex = (esInstance, esIndex) => {
         return `
     ${propsKey}: ${getAggsHistogramName(esgqlTypeMapping[entryType])}`;
       })}
-}
-`;
+}`;
     }
   }
   log.debug('[SCHEMA] AggsNestedTypeSchema: ', AggsNestedTypeSchema);

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -23,10 +23,13 @@ const getGQLType = (esInstance, esIndex, field, esFieldType) => {
     throw new Error(`Invalid type ${esFieldType} for field ${field} in index ${esIndex}`);
   }
   const isArrayField = esInstance.isArrayField(esIndex, field);
-  if (isArrayField) {
+  if (isArrayField && esFieldType !== 'nested') {
     return `[${gqlType}]`;
   }
   if (esFieldType === 'nested') {
+    if (isArrayField) {
+      return `[${field}]`;
+    }
     return `${field}`;
   }
   return gqlType;

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -76,3 +76,25 @@ export const fromFieldsToSource = (parsedInfo) => {
   }
   return fields;
 };
+
+export const buildNestedField = (key, value) => {
+  let builtObj = {};
+  if (value.type === 'nested') {
+    const nestedProps = [];
+    Object.keys(value.properties).forEach((propsKey) => {
+      nestedProps.push(buildNestedField(propsKey, value.properties[propsKey]));
+    });
+    builtObj = {
+      name: key,
+      type: value.type,
+      nestedProps,
+    };
+  } else {
+    builtObj = {
+      name: key,
+      type: value.type,
+    };
+  }
+
+  return builtObj;
+};

--- a/stories/connectedTable.jsx
+++ b/stories/connectedTable.jsx
@@ -13,7 +13,7 @@ storiesOf('Guppy Wrapper', module)
       <GuppyWrapper
         filterConfig={filterConfig}
         guppyConfig={guppyConfig}
-        rawDataFields={tableConfig.map(e => e.field)}
+        rawDataFields={tableConfig.map((e) => e.field)}
         onFilterChange={action('wrapper receive filter change')}
         onReceiveNewAggsData={action('wrapper receive aggs data')}
       >


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-4737

Adding support to nested aggregations
Example query:
```
query: {
  _aggregation: {
      visits: {
        visit_label: {
          histogram: {
            key
            count
          }
        }
        follow_ups: {
          days_to_follow_up: {
            histogram(rangeStep: 1) {
              key
              count
            }
          }
        }
      }
    }
  }
}
```
Result:
```
{
  "data": {
    "_aggregation": {
      "subject": {
        "visits": {
          "visit_label": {
            "histogram": [
              {
                "key": "vst_lbl_3",
                "count": 29
              },
              ...
            ]
          },
          "follow_ups": {
            "days_to_follow_up": {
              "histogram": [
                {
                  "key": [
                    1,
                    2
                  ],
                  "count": 21
                },
                ...
              ]
            }
          }
        }
      }
    }
  }
}
```

Deployed at https://mingfei.planx-pla.net/query

### New Features
- Supports aggregation on nested documents (nested aggregation)

### Dependency updates
- The current ES nested aggregation query syntax requires ES 6.7+ (note Guppy will not work for ES 7 yet)

