### PR TITLE
PXP-4733 Feat/nested explorer filter

### DIFF
--- a/doc/queries.md
+++ b/doc/queries.md
@@ -989,6 +989,27 @@ Assuming that there is `File` node nested inside `subject`. The nested query wil
 
 ElasticSearch only support the nested filter on the level of document for returning data. It means that the filter `file_count >=15` and `file_count<=75` will return the whole document having a `file_count` in the range of `[15, 75]`.
 The returned data will not filter the nested `file_count`(s) that are out of that range for that document.
+If the ES document has multi-level nested field, just update the `path` value.
+Example:
+```
+{
+  "filter": {
+    "AND": [
+      ...
+      {
+        "nested": {
+          "path": "visits.follow_ups",
+          "AND": [
+            {
+              ">=": {"days_to_follow_up": 15}
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
 
 <a name="other"></a>
 ## Some other queries and arguments 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1227,29 +1227,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@chromaui/localtunnel": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@chromaui/localtunnel/-/localtunnel-1.10.1.tgz",
-      "integrity": "sha512-LXhAogVc9SOQ45+mtk2mhcQxW4bE8aadfx9WbDzuDlBXcDgDMFBaxOmd5VYsPxQYA+cLFkKeuKOpROzsZSEySA==",
-      "dev": true,
-      "requires": {
-        "axios": "0.19.0",
-        "debug": "^3.0.1",
-        "openurl": "1.1.1",
-        "yargs": "6.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -4190,24 +4167,6 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
-    "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
-      }
-    },
     "axobject-query": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
@@ -4481,14 +4440,26 @@
       }
     },
     "babel-loader": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
-      "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
+      "integrity": "sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==",
       "requires": {
-        "find-cache-dir": "^2.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "pify": "^4.0.1"
+        "find-cache-dir": "^2.1.0",
+        "loader-utils": "^1.4.0",
+        "mkdirp": "^0.5.3",
+        "pify": "^4.0.1",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+          "integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
+          "requires": {
+            "ajv": "^6.12.0",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
       }
     },
     "babel-messages": {
@@ -5906,9 +5877,9 @@
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -6285,54 +6256,6 @@
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
         "tiny-emitter": "^2.0.0"
-      }
-    },
-    "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
       }
     },
     "clone-deep": {
@@ -7486,12 +7409,6 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
-    "denodeify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-      "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
-      "dev": true
-    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -7933,16 +7850,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
-    },
-    "env-ci": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-2.6.0.tgz",
-      "integrity": "sha512-tnOi9qgtDxY3mvf69coXLHbSZtFMNGAJ1s/huirAhJZTx9rs/1qgFjl+6Z5ULQCfpDmlsf34L7wm+eJGwMazYg==",
-      "dev": true,
-      "requires": {
-        "execa": "^1.0.0",
-        "java-properties": "^0.2.9"
-      }
     },
     "errno": {
       "version": "0.1.7",
@@ -8959,12 +8866,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "fake-tag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fake-tag/-/fake-tag-1.0.1.tgz",
-      "integrity": "sha512-qmewZoBpa71mM+y6oxXYW/d1xOYQmeIvnEXAt1oCmdP0sqcogWYLepR87QL1jQVLSVMVYDq2cjY6ec/Wu8/4pg==",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -8983,12 +8884,6 @@
         "micromatch": "^3.1.10"
       }
     },
-    "fast-json-parse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
-      "dev": true
-    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -8998,12 +8893,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "fast-safe-stringify": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz",
-      "integrity": "sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw==",
       "dev": true
     },
     "fault": {
@@ -9229,12 +9118,6 @@
         "rimraf": "2.6.3",
         "write": "1.0.3"
       }
-    },
-    "flatstr": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-      "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==",
-      "dev": true
     },
     "flatted": {
       "version": "2.0.1",
@@ -10271,18 +10154,11 @@
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
     },
     "gonzales-pe": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
-      "integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
       "requires": {
-        "minimist": "1.1.x"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "good-listener": {
@@ -11079,12 +10955,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "dev": true
-    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -11490,12 +11360,6 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
-    },
     "is-whitespace-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
@@ -11647,12 +11511,6 @@
         "iterate-iterator": "^1.0.1"
       }
     },
-    "java-properties": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz",
-      "integrity": "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w==",
-      "dev": true
-    },
     "jest": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
@@ -11756,8 +11614,7 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -12222,9 +12079,9 @@
           }
         },
         "yargs-parser": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -12676,15 +12533,6 @@
         }
       }
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "^1.0.0"
-      }
-    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -12748,13 +12596,13 @@
       }
     },
     "loader-fs-cache": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz",
-      "integrity": "sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.3.tgz",
+      "integrity": "sha512-ldcgZpjNJj71n+2Mf6yetz+c9bM4xpKtNds4LbqXzU/PTdeAX0g3ytnU1AJMEcTk2Lex4Smpe3Q/eCTsvUBxbA==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^0.1.1",
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "find-cache-dir": {
@@ -12919,12 +12767,6 @@
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
       }
-    },
-    "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -13276,9 +13118,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -13389,25 +13231,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -13504,15 +13333,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "dev": true,
-      "requires": {
-        "lower-case": "^1.1.1"
-      }
-    },
     "nock": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
@@ -13529,12 +13349,6 @@
         "qs": "^6.5.1",
         "semver": "^5.5.0"
       }
-    },
-    "node-ask": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-ask/-/node-ask-1.0.1.tgz",
-      "integrity": "sha1-yqoQdsxY4DZCZ6CQPj6t+sFYOWs=",
-      "dev": true
     },
     "node-dir": {
       "version": "0.1.17",
@@ -13609,17 +13423,6 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
-      }
-    },
-    "node-loggly-bulk": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/node-loggly-bulk/-/node-loggly-bulk-2.2.4.tgz",
-      "integrity": "sha512-DfhtsDfkSBU6Dp1zvK+H1MgHRcA2yb4z07ctyA6uo+bNwKtv1exhohN910zcWNkdSYq1TImCq+O+3bOTuYHvmQ==",
-      "dev": true,
-      "requires": {
-        "json-stringify-safe": "5.0.x",
-        "moment": "^2.18.1",
-        "request": ">=2.76.0 <3.0.0"
       }
     },
     "node-modules-regexp": {
@@ -13989,12 +13792,6 @@
         }
       }
     },
-    "openurl": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c=",
-      "dev": true
-    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -14042,15 +13839,6 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
-    },
-    "os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "^1.0.0"
-      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -14156,15 +13944,6 @@
         "cyclist": "^1.0.1",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
-      }
-    },
-    "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true,
-      "requires": {
-        "no-case": "^2.2.0"
       }
     },
     "parent-module": {
@@ -14391,33 +14170,6 @@
         "pinkie": "^2.0.0"
       }
     },
-    "pino": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.2.tgz",
-      "integrity": "sha512-hNNDgOju2UvK4iKqXR3ZwEutoOujBRN9jfQgty/X4B3q1QOqpWqvmVn+GT/a20o8Jw5Wd7VkGJAdgFQg55a+mw==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.3.0",
-        "fast-json-parse": "^1.0.0",
-        "fast-safe-stringify": "^1.2.1",
-        "flatstr": "^1.0.4",
-        "pump": "^1.0.3",
-        "quick-format-unescaped": "^1.1.1",
-        "split2": "^2.2.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -14520,9 +14272,9 @@
       "dev": true
     },
     "portfinder": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+      "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
@@ -15608,16 +15360,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "progress-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
-      "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
-      "dev": true,
-      "requires": {
-        "speedometer": "~1.0.0",
-        "through2": "~2.0.3"
-      }
-    },
     "promise": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
@@ -15813,15 +15555,6 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
-    },
-    "quick-format-unescaped": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.2.tgz",
-      "integrity": "sha1-DKWB3jF0vs7yWsPC6JVjQjgdtpg=",
-      "dev": true,
-      "requires": {
-        "fast-safe-stringify": "^1.0.8"
-      }
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -16435,15 +16168,14 @@
       }
     },
     "react-inspector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.0.tgz",
-      "integrity": "sha512-heh4THBeJg0HLYO/3VBAOaFPkdEHoTZq9VFgP4rOzGw/jyqdVd5spfXSl3LNB1fwrwaWef75Q1hCuwlY4GaKjQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.1.tgz",
+      "integrity": "sha512-xSiM6CE79JBqSj8Fzd9dWBHv57tLTH7OM57GP3VrE5crzVF3D5Khce9w1Xcw75OAbvrA0Mi2vBneR1OajKmXFg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "^7.6.3",
         "is-dom": "^1.0.9",
-        "prop-types": "^15.6.1",
-        "storybook-chromatic": "^2.2.2"
+        "prop-types": "^15.6.1"
       }
     },
     "react-is": {
@@ -16600,6 +16332,105 @@
           "requires": {
             "normalize-path": "^3.0.0",
             "picomatch": "^2.0.4"
+          }
+        },
+        "babel-loader": {
+          "version": "8.0.6",
+          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
+          "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
+          "dev": true,
+          "requires": {
+            "find-cache-dir": "^2.0.0",
+            "loader-utils": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "pify": "^4.0.1"
+          },
+          "dependencies": {
+            "find-cache-dir": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+              "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+              "dev": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "make-dir": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+              "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+              "dev": true,
+              "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+              "dev": true
+            },
+            "pify": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+              "dev": true
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+              "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+              "dev": true,
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
           }
         },
         "binary-extensions": {
@@ -19228,27 +19059,12 @@
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg=="
     },
-    "speedometer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
-      "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI=",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "^3.0.0"
-      }
-    },
-    "split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -19333,60 +19149,6 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.10.0.tgz",
       "integrity": "sha512-tWEpK0snS2RPUq1i3R6OahfJNjWCQYNxq0+by1amCSuw0mXtymJpzmZIeYpA1UAa+7B0grCpNYIbDcd7AgTbFg==",
       "dev": true
-    },
-    "storybook-chromatic": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/storybook-chromatic/-/storybook-chromatic-2.2.2.tgz",
-      "integrity": "sha512-n79eX0MQEHzDCnXqgOjvDOQ1xfBOTyQHy1RNxEMQvZolfAle8YVS0NnRpcW0xh/Ye621Iote3dwFI3uQmlcqPw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "@chromaui/localtunnel": "1.10.1",
-        "async-retry": "^1.1.4",
-        "commander": "^2.9.0",
-        "debug": "^3.0.1",
-        "denodeify": "^1.2.1",
-        "env-ci": "^2.1.0",
-        "fake-tag": "^1.0.0",
-        "jsdom": "^11.5.1",
-        "jsonfile": "^4.0.0",
-        "minimatch": "^3.0.4",
-        "node-ask": "^1.0.1",
-        "node-fetch": "^2.6.0",
-        "node-loggly-bulk": "^2.2.4",
-        "param-case": "^2.1.1",
-        "pino": "4.10.2",
-        "progress": "^2.0.3",
-        "progress-stream": "^2.0.0",
-        "semver": "^6.2.0",
-        "strip-color": "^0.1.0",
-        "tmp": "^0.1.0",
-        "tree-kill": "^1.1.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -19577,12 +19339,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-    },
-    "strip-color": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
-      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
-      "dev": true
     },
     "strip-comments": {
       "version": "1.0.2",
@@ -20122,15 +19878,6 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
-    "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dev": true,
-      "requires": {
-        "rimraf": "^2.6.3"
-      }
-    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -20224,12 +19971,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true
     },
     "trim": {
       "version": "0.0.1",
@@ -21073,16 +20814,16 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.41.6",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
-      "integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
+      "version": "4.43.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
+      "integrity": "sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.2.1",
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
@@ -21093,16 +20834,191 @@
         "loader-utils": "^1.2.3",
         "memory-fs": "^0.4.1",
         "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "neo-async": "^2.6.1",
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
         "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.0",
+        "watchpack": "^1.6.1",
         "webpack-sources": "^1.4.1"
       },
       "dependencies": {
+        "@webassemblyjs/ast": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+          "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/helper-module-context": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/wast-parser": "1.9.0"
+          }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+          "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+          "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+          "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+          "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/wast-printer": "1.9.0"
+          }
+        },
+        "@webassemblyjs/helper-fsm": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+          "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-module-context": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+          "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0"
+          }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+          "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+          "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0"
+          }
+        },
+        "@webassemblyjs/ieee754": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+          "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+          "dev": true,
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+          "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+          "dev": true,
+          "requires": {
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/utf8": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+          "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
+          "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+          "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/helper-wasm-section": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0",
+            "@webassemblyjs/wasm-opt": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0",
+            "@webassemblyjs/wast-printer": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+          "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/ieee754": "1.9.0",
+            "@webassemblyjs/leb128": "1.9.0",
+            "@webassemblyjs/utf8": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+          "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+          "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-api-error": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/ieee754": "1.9.0",
+            "@webassemblyjs/leb128": "1.9.0",
+            "@webassemblyjs/utf8": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wast-parser": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+          "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+            "@webassemblyjs/helper-api-error": "1.9.0",
+            "@webassemblyjs/helper-code-frame": "1.9.0",
+            "@webassemblyjs/helper-fsm": "1.9.0",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+          "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/wast-parser": "1.9.0",
+            "@xtuc/long": "4.2.2"
+          }
+        },
         "acorn": {
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
@@ -21124,6 +21040,17 @@
             "terser": "^4.1.2",
             "webpack-sources": "^1.4.0",
             "worker-farm": "^1.7.0"
+          }
+        },
+        "watchpack": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.1.tgz",
+          "integrity": "sha512-+IF9hfUFOrYOOaKyfaI7h7dquUIOgyEMoQMLA7OP5FxegKA2+XdXThAZ9TU2kucfhDH7rfMHs1oPYziVGWRnZA==",
+          "dev": true,
+          "requires": {
+            "chokidar": "^2.1.8",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0"
           }
         }
       }
@@ -21491,12 +21418,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
@@ -21910,167 +21831,6 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.3"
-      }
-    },
-    "yargs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-      "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^3.0.0",
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.2",
-        "which-module": "^1.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^4.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-          "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^3.0.0"
-          }
-        }
       }
     },
     "yargs-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11614,7 +11614,8 @@
         },
         "yargs-parser": {
           "version": "13.1.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9205,6 +9205,21 @@
         "locate-path": "^3.0.0"
       }
     },
+    "flat": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.0.tgz",
+      "integrity": "sha512-6KSMM+cHHzXC/hpldXApL2S8Uz+QZv+tq5o/L0KQYleoG+GcwrnIJhTWC7tCOiKQp8D/fIvryINU1OZCCwevjA==",
+      "requires": {
+        "is-buffer": "~2.0.4"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cors": "^2.8.5",
     "express": "^4.16.4",
     "file-saver": "^2.0.1",
+    "flat": "^5.0.0",
     "graphql": "^14.1.1",
     "graphql-middleware": "^3.0.2",
     "graphql-parse-resolve-info": "^4.1.0",

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -97,6 +97,13 @@ class ConnectedFilter extends React.Component {
       const selectedTabsOptions = {};
       const unselectedTabsOptions = {};
       Object.keys(processedTabsOptions).forEach((opt) => {
+        if (!processedTabsOptions[`${opt}`].histogram.length) {
+          if (!unselectedTabsOptions[`${opt}`]) {
+            unselectedTabsOptions[`${opt}`] = {};
+          }
+          unselectedTabsOptions[`${opt}`].histogram = [];
+          return;
+        }
         processedTabsOptions[`${opt}`].histogram.forEach((entry) => {
           if (this.state.filtersApplied[`${opt}`]
           && this.state.filtersApplied[`${opt}`].selectedValues
@@ -157,7 +164,6 @@ class ConnectedFilter extends React.Component {
     this.setState({ receivedAggsData });
     if (this.props.onReceiveNewAggsData) {
       const resultAggsData = excludeSelfFilterFromAggsData(receivedAggsData, filterResults);
-      console.log('resultAggsData: ', resultAggsData);
       this.props.onReceiveNewAggsData(resultAggsData);
     }
   }

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -98,7 +98,9 @@ class ConnectedFilter extends React.Component {
       const unselectedTabsOptions = {};
       Object.keys(processedTabsOptions).forEach((opt) => {
         processedTabsOptions[`${opt}`].histogram.forEach((entry) => {
-          if (this.state.filtersApplied[`${opt}`] && this.state.filtersApplied[`${opt}`].selectedValues.includes(entry.key)) {
+          if (this.state.filtersApplied[`${opt}`]
+          && this.state.filtersApplied[`${opt}`].selectedValues
+          && this.state.filtersApplied[`${opt}`].selectedValues.includes(entry.key)) {
             if (!selectedTabsOptions[`${opt}`]) {
               selectedTabsOptions[`${opt}`] = {};
             }
@@ -109,6 +111,10 @@ class ConnectedFilter extends React.Component {
           } else {
             if (!unselectedTabsOptions[`${opt}`]) {
               unselectedTabsOptions[`${opt}`] = {};
+            }
+            if (typeof (entry.key) !== 'string') { // if it is a range filter, just copy and return
+              unselectedTabsOptions[`${opt}`].histogram = processedTabsOptions[`${opt}`].histogram;
+              return;
             }
             if (!unselectedTabsOptions[`${opt}`].histogram) {
               unselectedTabsOptions[`${opt}`].histogram = [];
@@ -151,6 +157,7 @@ class ConnectedFilter extends React.Component {
     this.setState({ receivedAggsData });
     if (this.props.onReceiveNewAggsData) {
       const resultAggsData = excludeSelfFilterFromAggsData(receivedAggsData, filterResults);
+      console.log('resultAggsData: ', resultAggsData);
       this.props.onReceiveNewAggsData(resultAggsData);
     }
   }

--- a/src/components/ConnectedFilter/index.jsx
+++ b/src/components/ConnectedFilter/index.jsx
@@ -14,7 +14,12 @@ import {
   askGuppyForAggregationData,
   getAllFieldsFromFilterConfigs,
 } from '../Utils/queries';
-import { mergeFilters, updateCountsInInitialTabsOptions, sortTabsOptions } from '../Utils/filters';
+import {
+  mergeFilters,
+  updateCountsInInitialTabsOptions,
+  sortTabsOptions,
+  mergeTabOptions,
+} from '../Utils/filters';
 
 class ConnectedFilter extends React.Component {
   constructor(props) {
@@ -87,7 +92,36 @@ class ConnectedFilter extends React.Component {
       // for tiered access filters
       this.props.tierAccessLimit ? this.props.accessibleFieldCheckList : [],
     );
-    processedTabsOptions = sortTabsOptions(processedTabsOptions);
+    if (Object.keys(this.state.filtersApplied).length) {
+      // if has applied filters, sort tab options as selected/unselected separately
+      const selectedTabsOptions = {};
+      const unselectedTabsOptions = {};
+      Object.keys(processedTabsOptions).forEach((opt) => {
+        processedTabsOptions[`${opt}`].histogram.forEach((entry) => {
+          if (this.state.filtersApplied[`${opt}`] && this.state.filtersApplied[`${opt}`].selectedValues.includes(entry.key)) {
+            if (!selectedTabsOptions[`${opt}`]) {
+              selectedTabsOptions[`${opt}`] = {};
+            }
+            if (!selectedTabsOptions[`${opt}`].histogram) {
+              selectedTabsOptions[`${opt}`].histogram = [];
+            }
+            selectedTabsOptions[`${opt}`].histogram.push({ key: entry.key, count: entry.count });
+          } else {
+            if (!unselectedTabsOptions[`${opt}`]) {
+              unselectedTabsOptions[`${opt}`] = {};
+            }
+            if (!unselectedTabsOptions[`${opt}`].histogram) {
+              unselectedTabsOptions[`${opt}`].histogram = [];
+            }
+            unselectedTabsOptions[`${opt}`].histogram.push({ key: entry.key, count: entry.count });
+          }
+        });
+      });
+      processedTabsOptions = mergeTabOptions(sortTabsOptions(selectedTabsOptions),
+        sortTabsOptions(unselectedTabsOptions));
+    } else {
+      processedTabsOptions = sortTabsOptions(processedTabsOptions);
+    }
 
     if (!processedTabsOptions || Object.keys(processedTabsOptions).length === 0) return null;
     const { fieldMapping } = this.props;

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -38,7 +38,7 @@ const getSingleFilterOption = (histogramResult, initHistogramRes) => {
 };
 
 const capitalizeFirstLetter = (str) => {
-  const res = str.replace(/_/gi, ' ');
+  const res = str.replace(/_|\./gi, ' ');
   return res.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
 };
 

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -85,7 +85,7 @@ export const excludeSelfFilterFromAggsData = (receivedAggsData, filterResults) =
       }
       resultAggsData[`${actualFieldName}`] = { histogram: resultHistogram };
     } else {
-      resultAggsData[`${actualFieldName}`] = { histogram: receivedAggsData[field] };
+      resultAggsData[`${actualFieldName}`] = receivedAggsData[`${actualFieldName}`];
     }
   });
   return resultAggsData;

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -1,3 +1,4 @@
+import flat from 'flat';
 
 export const getFilterGroupConfig = (filterConfig) => ({
   tabs: filterConfig.tabs.map((t) => ({
@@ -71,18 +72,20 @@ export const getFilterSections = (
 export const excludeSelfFilterFromAggsData = (receivedAggsData, filterResults) => {
   if (!filterResults) return receivedAggsData;
   const resultAggsData = {};
-  Object.keys(receivedAggsData).forEach((field) => {
-    const { histogram } = receivedAggsData[field];
+  const flattenAggsData = flat(receivedAggsData, { safe: true });
+  Object.keys(flattenAggsData).forEach((field) => {
+    const actualFieldName = field.replace('.histogram', '');
+    const histogram = flattenAggsData[`${field}`];
     if (!histogram) return;
-    if (field in filterResults) {
+    if (actualFieldName in filterResults) {
       let resultHistogram = [];
-      if (typeof filterResults[field].selectedValues !== 'undefined') {
-        const { selectedValues } = filterResults[field];
+      if (typeof filterResults[`${actualFieldName}`].selectedValues !== 'undefined') {
+        const { selectedValues } = filterResults[`${actualFieldName}`];
         resultHistogram = histogram.filter((bucket) => selectedValues.includes(bucket.key));
       }
-      resultAggsData[field] = { histogram: resultHistogram };
+      resultAggsData[`${actualFieldName}`] = { histogram: resultHistogram };
     } else {
-      resultAggsData[field] = receivedAggsData[field];
+      resultAggsData[`${actualFieldName}`] = { histogram: receivedAggsData[field] };
     }
   });
   return resultAggsData;

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -85,7 +85,7 @@ export const excludeSelfFilterFromAggsData = (receivedAggsData, filterResults) =
       }
       resultAggsData[`${actualFieldName}`] = { histogram: resultHistogram };
     } else {
-      resultAggsData[`${actualFieldName}`] = receivedAggsData[`${actualFieldName}`];
+      resultAggsData[`${actualFieldName}`] = { histogram: flattenAggsData[`${field}`] };
     }
   });
   return resultAggsData;

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -8,7 +8,7 @@ import {
   askGuppyForTotalCounts,
   getAllFieldsFromGuppy,
   getAccessibleResources,
-  askGuppyForNestedAggregationData,
+  askGuppyForSubAggregationData,
 } from '../Utils/queries';
 import { ENUM_ACCESSIBILITY } from '../Utils/const';
 import { mergeFilters } from '../Utils/filters';
@@ -109,10 +109,10 @@ class GuppyWrapper extends React.Component {
       return Promise.resolve({ data: [], totalCount: 0 });
     }
 
-    // nested aggregation
+    // sub aggregations -- for DAT
     if (this.props.guppyConfig.mainField) {
       const numericAggregation = this.props.guppyConfig.mainFieldIsNumeric;
-      return askGuppyForNestedAggregationData(
+      return askGuppyForSubAggregationData(
         this.props.guppyConfig.path,
         this.props.guppyConfig.type,
         this.props.guppyConfig.mainField,

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -1,4 +1,4 @@
-/* eslint import/prefer-default-export: 0 */
+import flat from 'flat';
 
 /**
    * This function takes two objects containing filters to be applied
@@ -43,44 +43,53 @@ export const updateCountsInInitialTabsOptions = (
 ) => {
   const updatedTabsOptions = {};
   try {
-    Object.keys(initialTabsOptions).forEach((field) => {
-      updatedTabsOptions[field] = { histogram: [] };
+    // flatten the tab options first
+    // {
+    //   project_id.histogram: ...
+    //   visit.visit_label.histogram: ...
+    // }
+    const flattenInitialTabsOptions = flat(initialTabsOptions, { safe: true });
+    const flattenProcessedTabsOptions = flat(processedTabsOptions, { safe: true });
+    Object.keys(flattenInitialTabsOptions).forEach((field) => {
+      // in flattened tab options, to get actual field name, strip off the last '.histogram'
+      const actualFieldName = field.replace('.histogram', '');
+      // possible to have '.' in actualFieldName, so use it as a string
+      updatedTabsOptions[`${actualFieldName}`] = { histogram: [] };
       // if in tiered access mode
       // we need not to process filters for field in accessibleFieldCheckList
       if (accessibleFieldCheckList
-        && accessibleFieldCheckList.includes(field)
-        && processedTabsOptions[field]) {
-        updatedTabsOptions[field] = processedTabsOptions[field];
+        && accessibleFieldCheckList.includes(actualFieldName)
+        && flattenProcessedTabsOptions[`${field}`]) {
+        updatedTabsOptions[`${actualFieldName}`].histogram = flattenProcessedTabsOptions[`${field}`];
         return;
       }
-      const { histogram } = initialTabsOptions[field];
+      const histogram = flattenInitialTabsOptions[`${field}`];
       if (!histogram) {
-        console.error(`Guppy did not return histogram data for filter field ${field}`); // eslint-disable-line no-console
+        console.error(`Guppy did not return histogram data for filter field ${actualFieldName}`); // eslint-disable-line no-console
       }
       histogram.forEach((opt) => {
         const { key } = opt;
         if (typeof (key) !== 'string') { // key is a range, just copy the histogram
-          updatedTabsOptions[field].histogram = initialTabsOptions[field].histogram;
-          if (processedTabsOptions[field]
-            && processedTabsOptions[field].histogram
-            && processedTabsOptions[field].histogram.length > 0
-            && updatedTabsOptions[field].histogram) {
-            const newCount = processedTabsOptions[field].histogram[0].count;
-            updatedTabsOptions[field].histogram[0].count = newCount;
+          updatedTabsOptions[`${actualFieldName}`].histogram = flattenInitialTabsOptions[`${field}`];
+          if (flattenProcessedTabsOptions[`${field}`]
+            && flattenProcessedTabsOptions[`${field}`].length > 0
+            && updatedTabsOptions[`${actualFieldName}`].histogram) {
+            const newCount = flattenProcessedTabsOptions[`${field}`][0].count;
+            updatedTabsOptions[`${actualFieldName}`].histogram[0].count = newCount;
           }
           return;
         }
-        const findOpt = processedTabsOptions[field].histogram.find((o) => o.key === key);
+        const findOpt = flattenProcessedTabsOptions[`${field}`].find((o) => o.key === key);
         if (findOpt) {
           const { count } = findOpt;
-          updatedTabsOptions[field].histogram.push({ key, count });
+          updatedTabsOptions[`${actualFieldName}`].histogram.push({ key, count });
         }
       });
-      if (filtersApplied[field]) {
-        if (filtersApplied[field].selectedValues) {
-          filtersApplied[field].selectedValues.forEach((optKey) => {
-            if (!updatedTabsOptions[field].histogram.find((o) => o.key === optKey)) {
-              updatedTabsOptions[field].histogram.push({ key: optKey, count: 0 });
+      if (filtersApplied[`${actualFieldName}`]) {
+        if (filtersApplied[`${actualFieldName}`].selectedValues) {
+          filtersApplied[`${actualFieldName}`].selectedValues.forEach((optKey) => {
+            if (!updatedTabsOptions[`${actualFieldName}`].histogram.find((o) => o.key === optKey)) {
+              updatedTabsOptions[`${actualFieldName}`].histogram.push({ key: optKey, count: 0 });
             }
           });
         }

--- a/src/components/Utils/filters.js
+++ b/src/components/Utils/filters.js
@@ -1,4 +1,5 @@
 import flat from 'flat';
+import _ from 'lodash';
 
 /**
    * This function takes two objects containing filters to be applied
@@ -124,4 +125,32 @@ export const sortTabsOptions = (tabsOptions) => {
     sortedTabsOptions[field].histogram = optionsForThisField;
   }
   return sortedTabsOptions;
+};
+
+/**
+   * This function takes two TabsOptions object and merge them together
+   * The order of merged histogram array is preserved by firstHistogram.concat(secondHistogram)
+   */
+export const mergeTabOptions = (firstTabsOptions, secondTabsOptions) => {
+  if (!firstTabsOptions || !Object.keys(firstTabsOptions).length) {
+    return secondTabsOptions;
+  }
+  if (!secondTabsOptions || !Object.keys(secondTabsOptions).length) {
+    return firstTabsOptions;
+  }
+
+  const allOptionKeys = _.union(Object.keys(firstTabsOptions), Object.keys(secondTabsOptions));
+  const mergedTabOptions = {};
+  allOptionKeys.forEach((optKey) => {
+    if (!mergedTabOptions[`${optKey}`]) {
+      mergedTabOptions[`${optKey}`] = {};
+    }
+    if (!mergedTabOptions[`${optKey}`].histogram) {
+      mergedTabOptions[`${optKey}`].histogram = [];
+    }
+    const firstHistogram = (firstTabsOptions[`${optKey}`] && firstTabsOptions[`${optKey}`].histogram) ? firstTabsOptions[`${optKey}`].histogram : [];
+    const secondHistogram = (secondTabsOptions[`${optKey}`] && secondTabsOptions[`${optKey}`].histogram) ? secondTabsOptions[`${optKey}`].histogram : [];
+    mergedTabOptions[`${optKey}`].histogram = firstHistogram.concat(secondHistogram);
+  });
+  return mergedTabOptions;
 };

--- a/src/server/es/filter.js
+++ b/src/server/es/filter.js
@@ -266,7 +266,7 @@ const getFilterObj = (
     resultFilterObj = getESSearchFilterFragment(
       esInstance, esIndex, targetSearchFields, targetSearchKeyword,
     );
-  } else if (topLevelOp === 'nested') {
+  } else if (topLevelOpLowerCase === 'nested') {
     const { path } = graphqlFilterObj[topLevelOp];
     const filterOpObj = Object.keys(graphqlFilterObj[topLevelOp])
       .filter((key) => key !== 'path')
@@ -278,6 +278,12 @@ const getFilterObj = (
           aggsField, filterSelf, defaultAuthFilter, path),
       },
     };
+    // resultFilterObj.nested.query == null means nested filter contains target field
+    // AND `filterSelf` flag is false
+    // in this case, just apply an auth filter if exists
+    if (!resultFilterObj.nested.query) {
+      resultFilterObj = getFilterObj(esInstance, esIndex, defaultAuthFilter);
+    }
   } else {
     const field = Object.keys(graphqlFilterObj[topLevelOp])[0];
     if (aggsField === field && !filterSelf) {

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -1,7 +1,8 @@
 import GraphQLJSON from 'graphql-type-json';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
+import _ from 'lodash';
 import log from './logger';
-import { firstLetterUpperCase } from './utils/utils';
+import { firstLetterUpperCase, buildNestedFieldMapping } from './utils/utils';
 import { esFieldNumericTextTypeMapping, NumericTextTypeTypeEnum } from './es/const';
 
 /**
@@ -235,7 +236,10 @@ const getResolver = (esConfig, esInstance) => {
   }, {});
 
   const mappingResolvers = esConfig.indices.reduce((acc, cfg) => {
-    acc[cfg.type] = () => (esInstance.getESFields(cfg.index).fields.map((f) => f.name));
+    log.debug(`${cfg.index} `, esInstance.getESFields(cfg.index));
+    acc[cfg.type] = () => (_.flattenDeep(
+      esInstance.getESFields(cfg.index).fields.map((f) => buildNestedFieldMapping(f)),
+    ));
     return acc;
   }, {});
 

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -107,6 +107,5 @@ export const buildNestedFieldMapping = (field, parent) => {
     nestedFields,
     newParent,
   ));
-  // const result = resultArray.reduce((res, fieldName) => res.concat(fieldName).concat('\n'), '');
   return resultArray;
 };

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -95,6 +95,18 @@ export const buildNestedField = (key, value) => {
       type: value.type,
     };
   }
-
   return builtObj;
+};
+
+export const buildNestedFieldMapping = (field, parent) => {
+  if (!field.nestedProps) {
+    return (parent) ? `${parent}.${field.name}` : field.name;
+  }
+  const newParent = (parent) ? `${parent}.${field.name}` : field.name;
+  const resultArray = field.nestedProps.map((nestedFields) => buildNestedFieldMapping(
+    nestedFields,
+    newParent,
+  ));
+  // const result = resultArray.reduce((res, fieldName) => res.concat(fieldName).concat('\n'), '');
+  return resultArray;
 };

--- a/stories/downloadData.jsx
+++ b/stories/downloadData.jsx
@@ -14,7 +14,7 @@ storiesOf('Guppy Wrapper', module)
       <GuppyWrapper
         filterConfig={filterConfig}
         guppyConfig={guppyConfig}
-        rawDataFields={tableConfig.map(e => e.field)}
+        rawDataFields={tableConfig.map((e) => e.field)}
         onFilterChange={action('wrapper receive filter change')}
         onReceiveNewAggsData={action('wrapper receive aggs data')}
       >


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-4733

Let filters in data explorer support nested fields

To add a nested field to filter, just denote it with a `.`
Example:
>       "filters": {
>         "tabs": [
>           {
>             "title": "Subject",
>             "fields": [
>               "project_id",               --> a regular field
>               "visits.visit_label"      --> a nested field
>             ]
>           }
>         ]
>       },

By default any `.` and/or `_` will be converted to whitespaces and the character immediately after that will be captialized, e.g.: `visits.visit_label` will be displayed as `Visits Visit Label`.
To overwrite, use `fieldMapping`,
Example:
>       "guppyConfig": {
>         "dataType": "subject",
>         "fieldMapping": [
>           {"field": "visits.days_to_visit", "name": "Nested Days to Visit"}
>         ]
>       }

Deployed in https://qa-mickey.planx-pla.net/explorer

### New Features
- Let filters in data explorer support nested fields

### Improvements
- Selected filters will always show before unselected ones in filter sections