### PR TITLE
PXP-6412 Feat/auth mapping

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,10 @@ repos:
         hooks:
         -   id: detect-secrets
             args: ['--baseline', '.secrets.baseline']
+    -   repo: https://github.com/pre-commit/pre-commit-hooks
+        rev: v2.5.0
+        hooks:
+        -   id: trailing-whitespace
+        -   id: end-of-file-fixer
+        -   id: no-commit-to-branch
+            args: [--branch, develop, --branch, master, --pattern, release/.*]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,4 +4,3 @@ repos:
         hooks:
         -   id: detect-secrets
             args: ['--baseline', '.secrets.baseline']
-            exclude: .*/tests/.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/src/server/__mocks__/config.js
+++ b/src/server/__mocks__/config.js
@@ -19,7 +19,6 @@ const config = {
 
   port: 3000,
   path: '/graphql',
-  logLevel: 'DEBUG',
   tierAccessLevel: 'regular',
   tierAccessLimit: 20,
   arboristEndpoint: 'http://mock-arborist',

--- a/src/server/__mocks__/config.js
+++ b/src/server/__mocks__/config.js
@@ -19,6 +19,7 @@ const config = {
 
   port: 3000,
   path: '/graphql',
+  logLevel: 'DEBUG',
   tierAccessLevel: 'regular',
   tierAccessLimit: 20,
   arboristEndpoint: 'http://mock-arborist',

--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -252,6 +252,12 @@ const mockArborist = () => {
           method: 'update',
         },
       ],
+      'internal-project-4': [
+        {
+          service: '*',
+          method: '*',
+        },
+      ],
     });
 };
 

--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -206,7 +206,7 @@ const mockArborist = () => {
     .persist()
     .get('/auth/mapping')
     .reply(200, {
-      'internal-project-1': [
+      'internal-project-1': [ // accessible
         {
           service: '*',
           method: 'create',
@@ -228,13 +228,13 @@ const mockArborist = () => {
           method: 'update',
         },
       ],
-      'internal-project-2': [
+      'internal-project-2': [ // accessible
         {
           service: '*',
           method: 'read',
         },
       ],
-      'internal-project-3': [
+      'internal-project-3': [ // not accessible since method does not match
         {
           service: '*',
           method: 'create',
@@ -252,9 +252,21 @@ const mockArborist = () => {
           method: 'update',
         },
       ],
-      'internal-project-4': [
+      'internal-project-4': [ // accessible
         {
           service: '*',
+          method: '*',
+        },
+      ],
+      'internal-project-5': [ // accessible
+        {
+          service: 'guppy',
+          method: '*',
+        },
+      ],
+      'internal-project-6': [ // not accessible since service does not match
+        {
+          service: 'indexd',
           method: '*',
         },
       ],

--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -204,11 +204,53 @@ const mockResourcePath = () => {
 const mockArborist = () => {
   nock(config.arboristEndpoint)
     .persist()
-    .get('/auth/resources')
+    .get('/auth/mapping')
     .reply(200, {
-      resources: [
-        'internal-project-1',
-        'internal-project-2',
+      'internal-project-1': [
+        {
+          service: '*',
+          method: 'create',
+        },
+        {
+          service: '*',
+          method: 'delete',
+        },
+        {
+          service: '*',
+          method: 'read',
+        },
+        {
+          service: '*',
+          method: 'read-storage',
+        },
+        {
+          service: '*',
+          method: 'update',
+        },
+      ],
+      'internal-project-2': [
+        {
+          service: '*',
+          method: 'read',
+        },
+      ],
+      'internal-project-3': [
+        {
+          service: '*',
+          method: 'create',
+        },
+        {
+          service: '*',
+          method: 'delete',
+        },
+        {
+          service: '*',
+          method: 'read-storage',
+        },
+        {
+          service: '*',
+          method: 'update',
+        },
       ],
     });
 };

--- a/src/server/auth/__tests__/authHelper.test.js
+++ b/src/server/auth/__tests__/authHelper.test.js
@@ -12,8 +12,8 @@ setupMockDataEndpoint();
 describe('AuthHelper', () => {
   test('could create auth helper instance', async () => {
     const authHelper = await getAuthHelperInstance('fake-jwt');
-    expect(authHelper.getAccessibleResources()).toEqual(['internal-project-1', 'internal-project-2', 'internal-project-4']);
-    expect(authHelper.getAccessibleResources()).not.toContain(['internal-project-3']);
+    expect(authHelper.getAccessibleResources()).toEqual(['internal-project-1', 'internal-project-2', 'internal-project-4', 'internal-project-5']);
+    expect(authHelper.getAccessibleResources()).not.toContain(['internal-project-3', 'internal-project-6']);
     expect(authHelper.getUnaccessibleResources()).toEqual(['external-project-1', 'external-project-2']);
   });
 
@@ -53,6 +53,7 @@ describe('AuthHelper', () => {
           'internal-project-1',
           'internal-project-2',
           'internal-project-4',
+          'internal-project-5',
         ],
       },
     };
@@ -73,6 +74,7 @@ describe('AuthHelper', () => {
               'internal-project-1',
               'internal-project-2',
               'internal-project-4',
+              'internal-project-5',
             ],
           },
         },
@@ -112,6 +114,7 @@ describe('AuthHelper', () => {
           'internal-project-1',
           'internal-project-2',
           'internal-project-4',
+          'internal-project-5',
         ],
       },
     };

--- a/src/server/auth/__tests__/authHelper.test.js
+++ b/src/server/auth/__tests__/authHelper.test.js
@@ -12,7 +12,8 @@ setupMockDataEndpoint();
 describe('AuthHelper', () => {
   test('could create auth helper instance', async () => {
     const authHelper = await getAuthHelperInstance('fake-jwt');
-    expect(authHelper.getAccessibleResources()).toEqual(['internal-project-1', 'internal-project-2']);
+    expect(authHelper.getAccessibleResources()).toEqual(['internal-project-1', 'internal-project-2', 'internal-project-4']);
+    expect(authHelper.getAccessibleResources()).not.toContain(['internal-project-3']);
     expect(authHelper.getUnaccessibleResources()).toEqual(['external-project-1', 'external-project-2']);
   });
 
@@ -51,6 +52,7 @@ describe('AuthHelper', () => {
         gen3_resource_path: [
           'internal-project-1',
           'internal-project-2',
+          'internal-project-4',
         ],
       },
     };
@@ -70,6 +72,7 @@ describe('AuthHelper', () => {
             gen3_resource_path: [
               'internal-project-1',
               'internal-project-2',
+              'internal-project-4',
             ],
           },
         },
@@ -108,6 +111,7 @@ describe('AuthHelper', () => {
         gen3_resource_path: [
           'internal-project-1',
           'internal-project-2',
+          'internal-project-4',
         ],
       },
     };

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -10,7 +10,7 @@ class ArboristClient {
 
   listAuthorizedResources(jwt) {
     // Make request to arborist for list of resources with access
-    const resourcesEndpoint = `${this.baseEndpoint}/auth/resources`;
+    const resourcesEndpoint = `${this.baseEndpoint}/auth/mapping`;
     log.debug('[ArboristClient] listAuthorizedResources jwt: ', jwt);
     const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
     return fetch(
@@ -20,7 +20,19 @@ class ArboristClient {
         headers,
       },
     ).then(
-      (response) => response.json(),
+      (response) => {
+        const responseJSON = response.json();
+        const data = {
+          resources: [],
+        };
+        Object.keys(responseJSON).forEach((key) => {
+          if (responseJSON[key] && responseJSON[key].some((x) => x.method === 'read')) {
+            data.resources.push(key);
+          }
+        });
+        log.debug('[ArboristClient] data: ', data);
+        return data;
+      },
       (err) => {
         log.error(err);
         throw new CodedError(500, err);

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -20,24 +20,23 @@ class ArboristClient {
         headers,
       },
     ).then(
-      (response) => {
-        const responseJSON = response.json();
-        const data = {
-          resources: [],
-        };
-        Object.keys(responseJSON).forEach((key) => {
-          if (responseJSON[key] && responseJSON[key].some((x) => x.method === 'read')) {
-            data.resources.push(key);
-          }
-        });
-        log.debug('[ArboristClient] data: ', data);
-        return data;
-      },
-      (err) => {
-        log.error(err);
-        throw new CodedError(500, err);
-      },
-    );
+      (response) => response.json(),
+    ).then((result) => {
+      const data = {
+        resources: [],
+      };
+      Object.keys(result).forEach((key) => {
+        if (result[key] && result[key].some((x) => x.method === 'read')) {
+          data.resources.push(key);
+        }
+      });
+      log.debug('[ArboristClient] data: ', data);
+      return data;
+    },
+    (err) => {
+      log.error(err);
+      throw new CodedError(500, err);
+    });
   }
 }
 

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -26,7 +26,7 @@ class ArboristClient {
         resources: [],
       };
       Object.keys(result).forEach((key) => {
-        if (result[key] && result[key].some((x) => x.method === 'read')) {
+        if (result[key] && result[key].some((x) => x.method === 'read' || x.method === '*')) {
           data.resources.push(key);
         }
       });

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -26,13 +26,13 @@ class ArboristClient {
         resources: [],
       };
       Object.keys(result).forEach((key) => {
-        // logic: you have access to a project if you either
-        // 1. have 'read' access to a project resource
-        // or
-        // 2. have '*' access to service 'guppy' or service '*'
-        if (result[key] && result[key].some((x) => x.method === 'read'
-          || (x.method === '*' && (x.service === 'guppy' || x.service === '*')))
-        ) {
+        // logic: you have access to a project if you have the following access:
+        // method 'read' (or '*' - all methods) to service 'guppy' (or '*' - all services)
+        // on the project resource.
+        if (result[key] && result[key].some((x) => (
+          (x.method === 'read' || x.method === '*')
+          && (x.service === 'guppy' || x.service === '*')
+        ))) {
           data.resources.push(key);
         }
       });

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -26,7 +26,13 @@ class ArboristClient {
         resources: [],
       };
       Object.keys(result).forEach((key) => {
-        if (result[key] && result[key].some((x) => x.method === 'read' || x.method === '*')) {
+        // logic: you have access to a project if you either
+        // 1. have 'read' access to a project resource
+        // or
+        // 2. have '*' access to service 'guppy' or service '*'
+        if (result[key] && result[key].some((x) => x.method === 'read'
+          || (x.method === '*' && (x.service === 'guppy' || x.service === '*')))
+        ) {
           data.resources.push(key);
         }
       });

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -146,7 +146,6 @@ const getFieldAggregationResolverMappings = (esInstance, esIndex) => {
   return fieldAggregationResolverMappings;
 };
 
-
 /**
  * Tree-structured resolvers pass down arguments.
  * For better understanding, following is an example query, and related resolvers for each level:


### PR DESCRIPTION
Fulfills https://ctds-planx.atlassian.net/browse/PXP-6412

Deployed in: https://mingfei.planx-pla.net/ (should not see obvious changes)

### Improvements
- Switch Guppy from using Arborist's `/auth/resources` endpoint to `/auth/mapping` and filter out accessible list base on `read` access

### Breaking Changes
- User can only see/query the data for a project if they have the following access: method `read` (or `*` - all methods) to service `guppy` (or `*` - all services) on that project resource. (previously they can see/query all the data if you any types of access to them)
