### PR TITLE
(PXP-6359) Add Search Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Guppy
 
+
 [![npm (scoped)](https://img.shields.io/npm/v/@gen3/guppy)](https://www.npmjs.com/package/@gen3/guppy)
 
 Server that support GraphQL queries on data from elasticsearch.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Guppy
 
-
 [![npm (scoped)](https://img.shields.io/npm/v/@gen3/guppy)](https://www.npmjs.com/package/@gen3/guppy)
 
 Server that support GraphQL queries on data from elasticsearch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1548,9 +1548,8 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@gen3/ui-component": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.5.4.tgz",
-      "integrity": "sha512-tumarjK4ZaHFK2xOy7dwDo9laY/Dxi75ygX9/ib9C9Aa+fa8HBYllyK5TbJOj38w4kB0yx7qDE5cvjxa1ZOWyQ==",
+      "version": "github:uc-cdis/gen3-ui-component#a5924479fb555b4ae7fffea8e95970a991de99e0",
+      "from": "github:uc-cdis/gen3-ui-component#feat/pxp-6359-search-filter",
       "requires": {
         "@storybook/addon-actions": "^5.0.0",
         "@storybook/react": "^5.0.0",
@@ -1563,6 +1562,8 @@
         "react": "^16.8.4",
         "react-dom": "^16.8.4",
         "react-router-dom": "^4.3.1",
+        "react-select": "^3.1.0",
+        "react-select-async-paginate": "^0.4.0",
         "recharts": "^1.5.0",
         "stylelint": "^13.6.1"
       }
@@ -2022,6 +2023,11 @@
         "prop-types": "^15.6.1",
         "react-lifecycles-compat": "^3.0.4"
       }
+    },
+    "@seznam/compose-react-refs": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@seznam/compose-react-refs/-/compose-react-refs-1.0.4.tgz",
+      "integrity": "sha512-TwrojUAFVSd+HPAdnul0o65X8mIam+dJOxcWI6LhHAUIpVRk2cJp2dyWXWl6sJvZTY9ODSJpOibt7JKSNUjVfQ=="
     },
     "@storybook/addon-actions": {
       "version": "5.3.19",
@@ -2494,9 +2500,9 @@
       }
     },
     "@stylelint/postcss-css-in-js": {
-      "version": "0.37.1",
-      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.1.tgz",
-      "integrity": "sha512-UMf2Rni3JGKi3ZwYRGMYJ5ipOA5ENJSKMtYA/pE1ZLURwdh7B5+z2r73RmWvub+N0UuH1Lo+TGfCgYwPvqpXNw==",
+      "version": "0.37.2",
+      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
+      "integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
       "requires": {
         "@babel/core": ">=7.9.0"
       }
@@ -4144,7 +4150,8 @@
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -7396,9 +7403,9 @@
       "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "d3-format": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
-      "integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
     },
     "d3-interpolate": {
       "version": "1.4.0",
@@ -7440,9 +7447,9 @@
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "d3-time-format": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
-      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "requires": {
         "d3-time": "1"
       }
@@ -7853,11 +7860,19 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+          "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
+        }
       }
     },
     "dom-serializer": {
@@ -9198,6 +9213,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "fastq": {
       "version": "1.8.0",
@@ -12625,9 +12645,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -12802,6 +12822,11 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memoizerific": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
@@ -12820,17 +12845,15 @@
       }
     },
     "meow": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+      "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
       "requires": {
         "@types/minimist": "^1.2.0",
-        "arrify": "^2.0.1",
-        "camelcase": "^6.0.0",
         "camelcase-keys": "^6.2.2",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
+        "minimist-options": "4.1.0",
         "normalize-package-data": "^2.5.0",
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
@@ -12839,16 +12862,6 @@
         "yargs-parser": "^18.1.3"
       },
       "dependencies": {
-        "arrify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-        },
-        "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
-        },
         "type-fest": {
           "version": "0.13.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -15311,27 +15324,6 @@
         "postcss": "^7.0.2"
       }
     },
-    "postcss-reporter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
-      "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
-      "requires": {
-        "chalk": "^2.4.1",
-        "lodash": "^4.17.11",
-        "log-symbols": "^2.2.0",
-        "postcss": "^7.0.7"
-      },
-      "dependencies": {
-        "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-          "requires": {
-            "chalk": "^2.0.1"
-          }
-        }
-      }
-    },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
@@ -16246,6 +16238,14 @@
         "prop-types": "^15.6.1"
       }
     },
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-inspector": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.1.tgz",
@@ -16260,6 +16260,11 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-is-mounted-hook": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-is-mounted-hook/-/react-is-mounted-hook-1.0.3.tgz",
+      "integrity": "sha512-YCCYcTVYMPfTi6WhWIwM9EYBcpHoivjjkE90O5ScsE9wXSbeXGZvLDMGt4mdSNcWshhc8JD0AzgBmsleCSdSFA=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -17568,6 +17573,42 @@
         }
       }
     },
+    "react-select": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.0.tgz",
+      "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
+      }
+    },
+    "react-select-async-paginate": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/react-select-async-paginate/-/react-select-async-paginate-0.4.0.tgz",
+      "integrity": "sha512-57rjnsNy/doJ3RBgHLL4re4dsUeZnTm1EVD2LBsq6PL6JkvGqimnuKHCKBIqlpuuzRcxDY4Ffc7xjoQ4ZlOL1A==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@seznam/compose-react-refs": "^1.0.4",
+        "react-is-mounted-hook": "^1.0.3",
+        "sleep-promise": "^8.0.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "react-sizeme": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.12.tgz",
@@ -17588,6 +17629,27 @@
         "prop-types": "^15.6.0",
         "raf": "^3.4.0",
         "react-transition-group": "^2.5.0"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        }
       }
     },
     "react-syntax-highlighter": {
@@ -17623,14 +17685,14 @@
       }
     },
     "react-transition-group": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
       }
     },
     "read-pkg": {
@@ -17932,9 +17994,9 @@
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "remark": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-12.0.0.tgz",
-      "integrity": "sha512-oX4lMIS0csgk8AEbzY0h2jdR0ngiCHOpwwpxjmRa5TqAkeknY+tkhjRJGZqnCmvyuWh55/0SW5WY3R3nn3PH9A==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-12.0.1.tgz",
+      "integrity": "sha512-gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==",
       "requires": {
         "remark-parse": "^8.0.0",
         "remark-stringify": "^8.0.0",
@@ -17942,9 +18004,9 @@
       }
     },
     "remark-parse": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.2.tgz",
-      "integrity": "sha512-eMI6kMRjsAGpMXXBAywJwiwAse+KNpmt+BK55Oofy4KvBZEqUDj6mWbGLJZrujoPIPPxDXzn3T9baRlpsm2jnQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
+      "integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
       "requires": {
         "ccount": "^1.0.0",
         "collapse-white-space": "^1.0.2",
@@ -17980,9 +18042,9 @@
       }
     },
     "remark-stringify": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.0.tgz",
-      "integrity": "sha512-FSPZv1ds76oAZjurhhuV5qXSUSoz6QRPuwYK38S41sLHwg4oB7ejnmZshj7qwjgYLf93kdz6BOX9j5aidNE7rA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.1.tgz",
+      "integrity": "sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==",
       "requires": {
         "ccount": "^1.0.0",
         "is-alphanumeric": "^1.0.0",
@@ -18922,10 +18984,16 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
+    "sleep-promise": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-8.0.1.tgz",
+      "integrity": "sha1-jXlaJ+ojlT32tSuRCB5eImZZk8U="
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
@@ -18935,7 +19003,8 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         }
       }
     },
@@ -19616,18 +19685,20 @@
       }
     },
     "stylelint": {
-      "version": "13.6.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.6.1.tgz",
-      "integrity": "sha512-XyvKyNE7eyrqkuZ85Citd/Uv3ljGiuYHC6UiztTR6sWS9rza8j3UeQv/eGcQS9NZz/imiC4GKdk1EVL3wst5vw==",
+      "version": "13.7.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.1.tgz",
+      "integrity": "sha512-qzqazcyRxrSRdmFuO0/SZOJ+LyCxYy0pwcvaOBBnl8/2VfHSMrtNIE+AnyJoyq6uKb+mt+hlgmVrvVi6G6XHfQ==",
       "requires": {
-        "@stylelint/postcss-css-in-js": "^0.37.1",
+        "@stylelint/postcss-css-in-js": "^0.37.2",
         "@stylelint/postcss-markdown": "^0.36.1",
-        "autoprefixer": "^9.8.0",
+        "autoprefixer": "^9.8.6",
         "balanced-match": "^1.0.0",
         "chalk": "^4.1.0",
-        "cosmiconfig": "^6.0.0",
+        "cosmiconfig": "^7.0.0",
         "debug": "^4.1.1",
         "execall": "^2.0.0",
+        "fast-glob": "^3.2.4",
+        "fastest-levenshtein": "^1.0.12",
         "file-entry-cache": "^5.0.1",
         "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
@@ -19638,18 +19709,16 @@
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "known-css-properties": "^0.19.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "log-symbols": "^4.0.0",
         "mathml-tag-names": "^2.1.3",
-        "meow": "^7.0.1",
+        "meow": "^7.1.1",
         "micromatch": "^4.0.2",
         "normalize-selector": "^0.2.0",
         "postcss": "^7.0.32",
         "postcss-html": "^0.36.0",
         "postcss-less": "^3.1.4",
         "postcss-media-query-parser": "^0.2.3",
-        "postcss-reporter": "^6.0.1",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^4.0.2",
         "postcss-sass": "^0.4.4",
@@ -19665,7 +19734,7 @@
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^5.4.6",
+        "table": "^6.0.1",
         "v8-compile-cache": "^2.1.1",
         "write-file-atomic": "^3.0.3"
       },
@@ -19674,6 +19743,17 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
           "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+        },
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
         },
         "ansi-regex": {
           "version": "5.0.0",
@@ -19693,6 +19773,30 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
+        "autoprefixer": {
+          "version": "9.8.6",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
+          "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
+          "requires": {
+            "browserslist": "^4.12.0",
+            "caniuse-lite": "^1.0.30001109",
+            "colorette": "^1.2.1",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^7.0.32",
+            "postcss-value-parser": "^4.1.0"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001133",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001133.tgz",
+          "integrity": "sha512-s3XAUFaC/ntDb1O3lcw9K8MPeOW7KO3z9+GzAoBxfz1B0VdacXPMKgFUtG4KIsgmnbexmi013s9miVu4h+qMHw=="
         },
         "chalk": {
           "version": "4.1.0",
@@ -19716,6 +19820,18 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
         "dir-glob": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -19728,6 +19844,11 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-glob": {
           "version": "3.2.4",
@@ -19770,10 +19891,25 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
         },
         "string-width": {
           "version": "4.2.0",
@@ -19794,11 +19930,22 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.0.3.tgz",
+          "integrity": "sha512-8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==",
+          "requires": {
+            "ajv": "^6.12.4",
+            "lodash": "^4.17.20",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0"
           }
         }
       }
@@ -19927,6 +20074,7 @@
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -19937,17 +20085,20 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -19958,6 +20109,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -20522,9 +20674,9 @@
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
     },
     "unified": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
-      "integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.0.tgz",
+      "integrity": "sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==",
       "requires": {
         "bail": "^1.0.0",
         "extend": "^3.0.0",
@@ -20623,9 +20775,9 @@
       }
     },
     "unist-util-visit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
-      "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0",
@@ -20633,9 +20785,9 @@
       }
     },
     "unist-util-visit-parents": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
-      "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.0.tgz",
+      "integrity": "sha512-0g4wbluTF93npyPrp/ymd3tCDTMnP0yo2akFD2FIBAYXq/Sga3lwaU1D8OYKbtpioaI6CkDcQ6fsMnmtzt7htw==",
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
@@ -21070,9 +21222,9 @@
       }
     },
     "vfile": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
-      "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.0.tgz",
+      "integrity": "sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==",
       "requires": {
         "@types/unist": "^2.0.0",
         "is-buffer": "^2.0.0",
@@ -21089,9 +21241,9 @@
       }
     },
     "vfile-location": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
-      "integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.1.0.tgz",
+      "integrity": "sha512-FCZ4AN9xMcjFIG1oGmZKo61PjwJHRVA+0/tPUP2ul4uIwjGGndIxavEMRpWn5p4xwm/ZsdXp9YNygf1ZyE4x8g=="
     },
     "vfile-message": {
       "version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1548,7 +1548,7 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@gen3/ui-component": {
-      "version": "github:uc-cdis/gen3-ui-component#a5924479fb555b4ae7fffea8e95970a991de99e0",
+      "version": "github:uc-cdis/gen3-ui-component#00e490519f19d8e2dec961c846bbdaeb6ee84a54",
       "from": "github:uc-cdis/gen3-ui-component#feat/pxp-6359-search-filter",
       "requires": {
         "@storybook/addon-actions": "^5.0.0",
@@ -19794,9 +19794,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001133",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001133.tgz",
-          "integrity": "sha512-s3XAUFaC/ntDb1O3lcw9K8MPeOW7KO3z9+GzAoBxfz1B0VdacXPMKgFUtG4KIsgmnbexmi013s9miVu4h+qMHw=="
+          "version": "1.0.30001135",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
+          "integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ=="
         },
         "chalk": {
           "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1548,8 +1548,9 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@gen3/ui-component": {
-      "version": "github:uc-cdis/gen3-ui-component#00e490519f19d8e2dec961c846bbdaeb6ee84a54",
-      "from": "github:uc-cdis/gen3-ui-component#feat/pxp-6359-search-filter",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.6.0.tgz",
+      "integrity": "sha512-hjWGhd1FOVq/QAD9oI46hpEIbzjEQ1c0e25LTgREKe4k6fvEaPAADW29zsWAcxd7f01qXlDkJfRzI+lKQ6qCnA==",
       "requires": {
         "@storybook/addon-actions": "^5.0.0",
         "@storybook/react": "^5.0.0",
@@ -7523,9 +7524,9 @@
       }
     },
     "decimal.js-light": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.0.tgz",
-      "integrity": "sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -12609,11 +12610,10 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -17589,11 +17589,11 @@
       }
     },
     "react-select-async-paginate": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-select-async-paginate/-/react-select-async-paginate-0.4.0.tgz",
-      "integrity": "sha512-57rjnsNy/doJ3RBgHLL4re4dsUeZnTm1EVD2LBsq6PL6JkvGqimnuKHCKBIqlpuuzRcxDY4Ffc7xjoQ4ZlOL1A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-select-async-paginate/-/react-select-async-paginate-0.4.1.tgz",
+      "integrity": "sha512-zWeaN9C9PVQej4bz1+OvU6/ylHE6rHscDYcP+KiWdBedVQ5j2vXBjf/5RWLEvobvtUUHBOTbUF8+m2HDoeIcvQ==",
       "requires": {
-        "@babel/runtime": "^7.10.5",
+        "@babel/runtime": "^7.11.2",
         "@seznam/compose-react-refs": "^1.0.4",
         "react-is-mounted-hook": "^1.0.3",
         "sleep-promise": "^8.0.1"
@@ -19685,9 +19685,9 @@
       }
     },
     "stylelint": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.1.tgz",
-      "integrity": "sha512-qzqazcyRxrSRdmFuO0/SZOJ+LyCxYy0pwcvaOBBnl8/2VfHSMrtNIE+AnyJoyq6uKb+mt+hlgmVrvVi6G6XHfQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.2.tgz",
+      "integrity": "sha512-mmieorkfmO+ZA6CNDu1ic9qpt4tFvH2QUB7vqXgrMVHe5ENU69q7YDq0YUg/UHLuCsZOWhUAvcMcLzLDIERzSg==",
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
         "@stylelint/postcss-markdown": "^0.36.1",
@@ -19761,11 +19761,10 @@
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -19794,9 +19793,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001135",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
-          "integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ=="
+          "version": "1.0.30001144",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001144.tgz",
+          "integrity": "sha512-4GQTEWNMnVZVOFG3BK0xvGeaDAtiPAbG2N8yuMXuXzx/c2Vd4XoMPO8+E918zeXn5IF0FRVtGShBfkfQea2wHQ=="
         },
         "chalk": {
           "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/uc-cdis/guppy#readme",
   "dependencies": {
     "@elastic/elasticsearch": "^7.0.0-rc.1",
-    "@gen3/ui-component": "uc-cdis/gen3-ui-component#feat/pxp-6359-search-filter",
+    "@gen3/ui-component": "^0.6.0",
     "apollo-server": "^2.4.8",
     "apollo-server-express": "^2.4.8",
     "array.prototype.flat": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/uc-cdis/guppy#readme",
   "dependencies": {
     "@elastic/elasticsearch": "^7.0.0-rc.1",
-    "@gen3/ui-component": "^0.5.4",
+    "@gen3/ui-component": "uc-cdis/gen3-ui-component#feat/pxp-6359-search-filter",
     "apollo-server": "^2.4.8",
     "apollo-server-express": "^2.4.8",
     "array.prototype.flat": "^1.2.2",

--- a/src/components/ConnectedFilter/utils.js
+++ b/src/components/ConnectedFilter/utils.js
@@ -48,7 +48,9 @@ const capitalizeFirstLetter = (str) => {
 const createSearchFilterLoadOptionsFn = (field, guppyConfig) => (searchString, offset) => {
   const NUM_SEARCH_OPTIONS = 20;
   return new Promise((resolve, reject) => {
-    // If searchString is empty return all options
+    // If searchString is empty return just the first NUM_SEARCH_OPTIONS options.
+    // This allows the client to show default options in the search filter before
+    // the user has started searching.
     let filter = {};
     if (searchString) {
       filter = {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -338,6 +338,7 @@ GuppyWrapper.propTypes = {
     tabs: PropTypes.arrayOf(PropTypes.shape({
       title: PropTypes.string,
       fields: PropTypes.arrayOf(PropTypes.string),
+      searchFields: PropTypes.arrayOf(PropTypes.string),
     })),
   }).isRequired,
   rawDataFields: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -446,31 +446,3 @@ export const getAccessibleResources = async (
   });
   return { accessibleFieldObject, unaccessibleFieldObject };
 };
-
-export const guppySinglefieldSearch = (path, type, keyword, field, numResults) => {
-  const query = `query ($filter: JSON) {
-    ${type} (filter: $filter, first: ${numResults}) {
-      ${field}
-      _matched {
-        field
-        highlights
-      }
-    }
-  }`;
-  const filter = `{
-    "search": {
-      "keyword": "${keyword}",
-      "fields":  "${field}",
-    }
-  }`;
-  const queryBody = { query };
-  queryBody.variables.filter = filter;
-
-  return fetch(`${path}${graphqlEndpoint}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(queryBody),
-  }).then((response) => response.json());
-};

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -143,7 +143,7 @@ const rawDataQueryStrForEachField = (field) => {
   }`);
 };
 
-const queryGuppyForRawDataAndTotalCounts = (
+export const queryGuppyForRawDataAndTotalCounts = (
   path,
   type,
   fields,
@@ -291,6 +291,7 @@ export const askGuppyForRawData = (
 };
 
 export const getAllFieldsFromFilterConfigs = (filterTabConfigs) => filterTabConfigs
+  // TODO modify to include searchFields?? Or not... figure out if we need this for auth or sth
   .reduce((acc, cur) => acc.concat(cur.fields), []);
 
 /**
@@ -445,4 +446,32 @@ export const getAccessibleResources = async (
     unaccessibleFieldObject[res.field] = res.list;
   });
   return { accessibleFieldObject, unaccessibleFieldObject };
+};
+
+export const guppySinglefieldSearch = (path, type, keyword, field, numResults) => {
+  const query = `query ($filter: JSON) {
+    ${type} (filter: $filter, first: ${numResults}) {
+      ${field}
+      _matched {
+        field
+        highlights
+      }
+    }
+  }`;
+  const filter = `{
+    "search": {
+      "keyword": "${keyword}",
+      "fields":  "${field}",
+    }
+  }`;
+  const queryBody = { query };
+  queryBody.variables.filter = filter;
+
+  return fetch(`${path}${graphqlEndpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(queryBody),
+  }).then((response) => response.json());
 };

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -291,7 +291,6 @@ export const askGuppyForRawData = (
 };
 
 export const getAllFieldsFromFilterConfigs = (filterTabConfigs) => filterTabConfigs
-  // TODO modify to include searchFields?? Or not... figure out if we need this for auth or sth
   .reduce((acc, cur) => acc.concat(cur.fields), []);
 
 /**


### PR DESCRIPTION
Jira Ticket: [PXP-6359](https://ctds-planx.atlassian.net/browse/PXP-6359)

### New Features
- Adds a new filter type, `searchFilter`, to the available filters. Search Filters allow the user to search over fields which have too many options to be displayed normally -- for example, individual subject IDs or file GUIDs.


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- To deploy SearchFilters in a tab of the Explorer page, add an entry to `data{/file}ExplorerConfig.filters.tabs.searchFields`. **NOTE: Do not add the same field to both `searchFields` and `fields`**, this will cause strange behavior in the search field. Example config: 
```
"filters": {
      "tabs": [
        {
          "title": "Subject",
          "searchFields": [
            "subject_id",
            "submitter_id",
            "consent_codes"
          ],
          "fields": [
            "data_type",
            "data_format",
            ...
          ]
        }
```

