### PR TITLE
feat: per-index tiered-access middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ You could put following as your config files:
   "indices": [
     {
       "index": "${ES_INDEX_1}",
-      "type": "${ES_DOC_TYPE_1}"
+      "type": "${ES_DOC_TYPE_1}",
+      "tier_access_level": "${ES_TIER_ACCESS_LEVEL_1}" // optional, set this if there is no global tierAccessLevel
     },
     {
       "index": "${ES_INDEX_2}",
-      "type": "${ES_DOC_TYPE_2}"
+      "type": "${ES_DOC_TYPE_2}",
+      "tier_access_level": "${ES_TIER_ACCESS_LEVEL_2}"  // optional, set this if there is no global tierAccessLevel
     },
     ...
   ],
@@ -34,6 +36,8 @@ You could put following as your config files:
   "missing_data_alias": "no data", // optional, only valid if `aggs_include_missing_data` is true, guppy will alias missing data into this keyword during aggregation. By default it's set to `no data`.
 }
 ```
+
+Note: Guppy expects that either all indices in the guppy config block will have a tiered-access level set OR that a site-wide tiered-access level is set in the global block of the manifest. Guppy will throw an error if the config settings do not meet one of these two expectations. See `doc/index_scoped_tiered_access.md` for more information.
 
 Following script will start server using at port 3000, using config file `example_config.json`:
 
@@ -58,7 +62,7 @@ behavior for local test without Arborist, just set `INTERNAL_LOCAL_TEST=true`. P
 look into `/src/server/auth/utils.js` for more details.
 
 ### Tiered Access:
-Guppy also support 3 different levels of tier access, by setting `TIER_ACCESS_LEVEL`:
+Guppy support 3 different levels of tier access, by setting `TIER_ACCESS_LEVEL`:
 - `private` by default: only allows access to authorized resources
 - `regular`: allows all kind of aggregation (with limitation for unauthorized resources), but forbid access to raw data without authorization
 - `libre`: access to all data
@@ -68,7 +72,8 @@ For `regular` level, there's another configuration environment variable `TIER_AC
 `regular` level commons could also take in a whitelist of values that won't be encrypted. It is set by `config.encrypt_whitelist`.
 By default the whitelist contains missing values: ['\_\_missing\_\_', 'unknown', 'not reported', 'no data'].
 Also the whitelist is disabled by default due to security reasons. If you would like to enable whitelist, simply put `enable_encrypt_whitelist: true` in your config.
-For example `regular` leveled commons with config looks like this will skip encrypting value `do-not-encrypt-me` even if its count is less than `TIER_ACCESS_LIMIT`:
+
+For example, a `regular` leveled commons with config looks like this will skip encrypting value `do-not-encrypt-me` even if its count is less than `TIER_ACCESS_LIMIT`:
 
 ```
 {
@@ -89,13 +94,17 @@ For example `regular` leveled commons with config looks like this will skip encr
 }
 ```
 
-For example following script will start a Guppy server with `regular` tier access level, and minimum visible count set to 100:
+Tiered-access can be configured in either a site-wide manner or with per-index scoping. To configure tiered-access at the site-wide level, use the tierAccessLevel property in the global block of the manifest.json. The above example is a site-wide tiered-access configuration.
+
+The following script will start a Guppy server with a site-wide `regular` tier access level, and minimum visible count set to 100:
 
 ```
 export TIER_ACCESS_LEVEL=regular
 export TIER_ACCESS_LIMIT=100
 npm start
 ```
+
+To learn how to configure Guppy's tiered-access system using a per-index scoping, and which use cases might warrant such a configuration, please see `doc/index_scoped_tiered_access.md`.
 
 > #### Tier Access Sensitive Record Exclusion
 > It is possible to configure Guppy to hide some records from being returned in `_aggregation` queries when Tiered Access is enabled (tierAccessLevel: "regular").

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ For `regular` level, there's another configuration environment variable `TIER_AC
 `regular` level commons could also take in a whitelist of values that won't be encrypted. It is set by `config.encrypt_whitelist`.
 By default the whitelist contains missing values: ['\_\_missing\_\_', 'unknown', 'not reported', 'no data'].
 Also the whitelist is disabled by default due to security reasons. If you would like to enable whitelist, simply put `enable_encrypt_whitelist: true` in your config.
-
 For example, a `regular` leveled commons with config looks like this will skip encrypting value `do-not-encrypt-me` even if its count is less than `TIER_ACCESS_LIMIT`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ behavior for local test without Arborist, just set `INTERNAL_LOCAL_TEST=true`. P
 look into `/src/server/auth/utils.js` for more details.
 
 ### Tiered Access:
-Guppy support 3 different levels of tier access, by setting `TIER_ACCESS_LEVEL`:
+The tiered-access setting is configured through either the `TIER_ACCESS_LEVEL` environment variable or the `tier_access_level` properties on individual indices in the esConfig. Guppy supports 3 different levels of tiered access:
 - `private` by default: only allows access to authorized resources
 - `regular`: allows all kind of aggregation (with limitation for unauthorized resources), but forbid access to raw data without authorization
 - `libre`: access to all data

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You could put following as your config files:
 }
 ```
 
-Note: Guppy expects that either all indices in the guppy config block will have a tiered-access level set OR that a site-wide tiered-access level is set in the global block of the manifest. Guppy will throw an error if the config settings do not meet one of these two expectations. See `doc/index_scoped_tiered_access.md` for more information.
+Note: Guppy expects that either all indices in the guppy config block will have a tier_access_level set OR that a site-wide TIER_ACCESS_LEVEL is set as an environment variable (or in the global block of a commons' manifest). Guppy will throw an error if the config settings do not meet one of these two expectations. See `doc/index_scoped_tiered_access.md` for more information.
 
 Following script will start server using at port 3000, using config file `example_config.json`:
 
@@ -67,12 +67,12 @@ Guppy support 3 different levels of tier access, by setting `TIER_ACCESS_LEVEL`:
 - `regular`: allows all kind of aggregation (with limitation for unauthorized resources), but forbid access to raw data without authorization
 - `libre`: access to all data
 
-For `regular` level, there's another configuration environment variable `TIER_ACCESS_LIMIT`, which is the minimum visible count for aggregation results.
+For the `regular` level, there's another configuration environment variable `TIER_ACCESS_LIMIT`, which is the minimum visible count for aggregation results.
 
-`regular` level commons could also take in a whitelist of values that won't be encrypted. It is set by `config.encrypt_whitelist`.
+`regular` level commons can also take in a whitelist of values that won't be encrypted. It is set by `config.encrypt_whitelist`.
 By default the whitelist contains missing values: ['\_\_missing\_\_', 'unknown', 'not reported', 'no data'].
 Also the whitelist is disabled by default due to security reasons. If you would like to enable whitelist, simply put `enable_encrypt_whitelist: true` in your config.
-For example, a `regular` leveled commons with config looks like this will skip encrypting value `do-not-encrypt-me` even if its count is less than `TIER_ACCESS_LIMIT`:
+For example, a `regular` leveled commons with config that looks like this will skip encrypting the value `do-not-encrypt-me` even if its count is less than `TIER_ACCESS_LIMIT`:
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -93,8 +93,6 @@ For example, a `regular` leveled commons with config that looks like this will s
 }
 ```
 
-Tiered-access can be configured in either a site-wide manner or with per-index scoping. To configure tiered-access at the site-wide level, use the tierAccessLevel property in the global block of the manifest.json. The above example is a site-wide tiered-access configuration.
-
 The following script will start a Guppy server with a site-wide `regular` tier access level, and minimum visible count set to 100:
 
 ```

--- a/doc/docs:index_scoped_tiered_access.md
+++ b/doc/docs:index_scoped_tiered_access.md
@@ -1,0 +1,40 @@
+# Index-scoped Tiered-Access
+
+Most commons tend to use a site-wide tiered access configuration that applies across indices. However, some use cases require index-scoped permissioning. One example is the case of an open-access study viewer where studies have a mix of public properties and controlled-access properties. Another example is a Data Explorer that presents data types with different permission requirements meant to serve a variety of audiences.
+
+For these use cases, tiered-access settings can be specified at the index-level rather than the site-wide level. The expectation is that either a site-wide tiered-access level is set in the global block of the manifest OR all indices in the guppy config block have a tiered-access level set. Guppy will throw an error if the config settings do not meet one of these two expectations.
+
+You can set index-scoped tiered-access levels using the `tier_access_level` properties index objects in the guppy block of a common's `manifest.json`. Note that the `tier_access_limit` setting is still site-wide and configurable in the manifest's `global` block.
+```
+"guppy": {
+    "indices": [
+      {
+        "index": "subject_regular",
+        "type": "subject",
+	    "tier_access_level": "regular"
+      },
+      {
+        "index": "subject_private",
+        "type": "subject_private",
+	    "tier_access_level": "private"
+      },
+      {
+        "index": "file_private",
+        "type": "file",
+	    "tier_access_level": "private"
+      },
+      {
+        "index": "studies_open",
+        "type": "studies_open",
+	    "tier_access_level": "libre"
+      },
+      {
+        "index": "studies_controlled_access",
+        "type": "studies_controlled_access",
+	    "tier_access_level": "private"
+      }
+    ],
+    "auth_filter_field": "auth_resource_path",
+    ...
+  },
+```

--- a/doc/docs:index_scoped_tiered_access.md
+++ b/doc/docs:index_scoped_tiered_access.md
@@ -1,10 +1,10 @@
 # Index-scoped Tiered-Access
 
-Most commons tend to use a site-wide tiered access configuration that applies across indices. However, some use cases require index-scoped permissioning. One example is the case of an open-access study viewer where studies have a mix of public properties and controlled-access properties. Another example is a Data Explorer that presents data types with different permission requirements meant to serve a variety of audiences.
+Most commons use a site-wide tiered access configuration that applies across indices. However, some use cases require index-scoped permissioning. One example is the case of an open-access study viewer where studies have a mix of public properties and controlled-access properties. Another example is a Data Explorer that presents data types with different permission requirements meant to serve a variety of audiences. For these use cases, tiered-access settings can be specified at the index-level rather than the site-wide level. 
 
-For these use cases, tiered-access settings can be specified at the index-level rather than the site-wide level. The expectation is that either a site-wide tiered-access level is set in the global block of the manifest OR all indices in the guppy config block have a tiered-access level set. Guppy will throw an error if the config settings do not meet one of these two expectations.
+Guppy expects that either all indices in the guppy config block will have a tiered-access level set OR that a site-wide tiered-access level is set in the global block of the manifest. Guppy will throw an error if the config settings do not meet one of these two expectations.
 
-You can set index-scoped tiered-access levels using the `tier_access_level` properties index objects in the guppy block of a common's `manifest.json`. Note that the `tier_access_limit` setting is still site-wide and configurable in the manifest's `global` block.
+You can set index-scoped tiered-access levels using the `tier_access_level` properties in the guppy block of a common's `manifest.json`. Note that the `tier_access_limit` setting is still site-wide and configurable in the manifest's `global` block.
 ```
 "guppy": {
     "indices": [

--- a/doc/index_scoped_tiered_access.md
+++ b/doc/index_scoped_tiered_access.md
@@ -6,32 +6,33 @@ Guppy expects that either all indices in the guppy config block will have a tier
 
 You can set index-scoped tiered-access levels using the `tier_access_level` properties in the guppy block of a common's `manifest.json`. Note that the `tier_access_limit` setting is still site-wide and configurable in the manifest's `global` block.
 ```
+...
 "guppy": {
     "indices": [
       {
         "index": "subject_regular",
         "type": "subject",
-	    "tier_access_level": "regular"
+	"tier_access_level": "regular"
       },
       {
         "index": "subject_private",
         "type": "subject_private",
-	    "tier_access_level": "private"
+	"tier_access_level": "private"
       },
       {
         "index": "file_private",
         "type": "file",
-	    "tier_access_level": "private"
+	"tier_access_level": "private"
       },
       {
         "index": "studies_open",
         "type": "studies_open",
-	    "tier_access_level": "libre"
+	"tier_access_level": "libre"
       },
       {
         "index": "studies_controlled_access",
         "type": "studies_controlled_access",
-	    "tier_access_level": "private"
+	"tier_access_level": "private"
       }
     ],
     "auth_filter_field": "auth_resource_path",

--- a/doc/index_scoped_tiered_access.md
+++ b/doc/index_scoped_tiered_access.md
@@ -12,27 +12,27 @@ You can set index-scoped tiered-access levels using the `tier_access_level` prop
       {
         "index": "subject_regular",
         "type": "subject",
-	"tier_access_level": "regular"
+        "tier_access_level": "regular"
       },
       {
         "index": "subject_private",
         "type": "subject_private",
-	"tier_access_level": "private"
+        "tier_access_level": "private"
       },
       {
         "index": "file_private",
         "type": "file",
-	"tier_access_level": "private"
+        "tier_access_level": "private"
       },
       {
         "index": "studies_open",
         "type": "studies_open",
-	"tier_access_level": "libre"
+        "tier_access_level": "libre"
       },
       {
         "index": "studies_controlled_access",
         "type": "studies_controlled_access",
-	"tier_access_level": "private"
+        "tier_access_level": "private"
       }
     ],
     "auth_filter_field": "auth_resource_path",

--- a/src/server/__tests__/config.test.js
+++ b/src/server/__tests__/config.test.js
@@ -53,7 +53,7 @@ describe('config', () => {
     const config = require('../config').default;
     const { indices } = require(fileName);
     expect(config.tierAccessLevel).toBeUndefined();
-    expect(config.tierAccessLevel).toEqual(50);
+    expect(config.tierAccessLimit).toEqual(50);
     expect(JSON.stringify(config.esConfig.indices)).toEqual(JSON.stringify(indices));
   });
 

--- a/src/server/__tests__/config.test.js
+++ b/src/server/__tests__/config.test.js
@@ -42,12 +42,12 @@ describe('config', () => {
     const fileName = './testConfigFiles/test-invalid-index-scoped-tier-access.json';
     process.env.GUPPY_CONFIG_FILEPATH = `${__dirname}/${fileName}`;
     const invalidItemType = 'subject_private';
-    expect(() => (require('../config'))).toThrow(new Error(`tier_access_level invalid for index ${invalidItemType}."`));
+    expect(() => (require('../config'))).toThrow(new Error(`tier_access_level invalid for index ${invalidItemType}.`));
   });
 
   test('clears out site-wide default tiered-access setting if index-scoped levels set', async () => {
     process.env.TIER_ACCESS_LEVEL = null;
-    const fileName = './testConfigFiles/test-invalid-index-scoped-tier-access.json';
+    const fileName = './testConfigFiles/test-index-scoped-tier-access.json';
     process.env.GUPPY_CONFIG_FILEPATH = `${__dirname}/${fileName}`;
     const config = require('../config').default;
     const { indices } = require(fileName);

--- a/src/server/__tests__/config.test.js
+++ b/src/server/__tests__/config.test.js
@@ -51,7 +51,7 @@ describe('config', () => {
     process.env.GUPPY_CONFIG_FILEPATH = `${__dirname}/${fileName}`;
     const config = require('../config').default;
     const { indices } = require(fileName);
-    expect(config.tierAccessLevel).toBe(null);
+    expect(config.tierAccessLevel).toBeUndefined();
     expect(JSON.stringify(config.esConfig.indices)).toEqual(JSON.stringify(indices));
   });
 

--- a/src/server/__tests__/config.test.js
+++ b/src/server/__tests__/config.test.js
@@ -47,11 +47,13 @@ describe('config', () => {
 
   test('clears out site-wide default tiered-access setting if index-scoped levels set', async () => {
     process.env.TIER_ACCESS_LEVEL = null;
+    process.env.TIER_ACCESS_LIMIT = 50;
     const fileName = './testConfigFiles/test-index-scoped-tier-access.json';
     process.env.GUPPY_CONFIG_FILEPATH = `${__dirname}/${fileName}`;
     const config = require('../config').default;
     const { indices } = require(fileName);
     expect(config.tierAccessLevel).toBeUndefined();
+    expect(config.tierAccessLevel).toEqual(50);
     expect(JSON.stringify(config.esConfig.indices)).toEqual(JSON.stringify(indices));
   });
 

--- a/src/server/__tests__/config.test.js
+++ b/src/server/__tests__/config.test.js
@@ -37,6 +37,24 @@ describe('config', () => {
     expect(() => (require('../config'))).toThrow(new Error(`Invalid TIER_ACCESS_LEVEL "${process.env.TIER_ACCESS_LEVEL}"`));
   });
 
+  test('should show error if invalid tier access level in guppy block', async () => {
+    process.env.TIER_ACCESS_LEVEL = null;
+    const fileName = './testConfigFiles/test-invalid-index-scoped-tier-access.json';
+    process.env.GUPPY_CONFIG_FILEPATH = `${__dirname}/${fileName}`;
+    const invalidItemType = 'subject_private';
+    expect(() => (require('../config'))).toThrow(new Error(`tier_access_level invalid for index ${invalidItemType}."`));
+  });
+
+  test('clears out site-wide default tiered-access setting if index-scoped levels set', async () => {
+    process.env.TIER_ACCESS_LEVEL = null;
+    const fileName = './testConfigFiles/test-invalid-index-scoped-tier-access.json';
+    process.env.GUPPY_CONFIG_FILEPATH = `${__dirname}/${fileName}`;
+    const config = require('../config').default;
+    const { indices } = require(fileName);
+    expect(config.tierAccessLevel).toBe(null);
+    expect(JSON.stringify(config.esConfig.indices)).toEqual(JSON.stringify(indices));
+  });
+
   /* --------------- For whitelist --------------- */
   test('could disable whitelist', async () => {
     const config = require('../config').default;

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -6,6 +6,7 @@ import {
   getAggregationSchema,
   getAggregationSchemaForEachType,
   getMappingSchema,
+  getHistogramSchemas,
 } from '../schema';
 import esInstance from '../es/index';
 import config from '../config';

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -143,4 +143,36 @@ describe('Schema', () => {
     expect(removeSpacesNewlinesAndDes(mappingSchema))
       .toEqual(removeSpacesAndNewlines(expectedMappingSchema));
   });
+
+  const expectedHistogramSchemas = `
+  type HistogramForString {
+    histogram: [BucketsForNestedStringAgg]
+  }
+  type RegularAccessHistogramForString {
+    histogram: [BucketsForNestedStringAgg]
+  }
+  type HistogramForNumber {
+    histogram(
+      rangeStart: Int,
+      rangeEnd: Int,
+      rangeStep: Int,
+      binCount: Int,
+    ): [BucketsForNestedNumberAgg],
+    asTextHistogram: [BucketsForNestedStringAgg]
+  }
+  type RegularAccessHistogramForNumber {
+    histogram(
+      rangeStart: Int,
+      rangeEnd: Int,
+      rangeStep: Int,
+      binCount: Int,
+    ): [BucketsForNestedNumberAgg],
+    asTextHistogram: [BucketsForNestedStringAgg]
+  }`;
+  test('could create histogram schemas for each type', async () => {
+    await esInstance.initialize();
+    const histogramSchemas = getHistogramSchemas();
+    expect(removeSpacesNewlinesAndDes(histogramSchemas))
+      .toEqual(removeSpacesAndNewlines(expectedHistogramSchemas));
+  });
 });

--- a/src/server/__tests__/testConfigFiles/test-index-scoped-tier-access.json
+++ b/src/server/__tests__/testConfigFiles/test-index-scoped-tier-access.json
@@ -1,29 +1,29 @@
 {
     "indices": [
-      {
-        "index": "subject_regular",
-        "type": "subject",
-        "tier_access_level": "regular"
-      },
-      {
-        "index": "subject_private",
-        "type": "subject_private",
-        "tier_access_level": "private"
-      },
-      {
-        "index": "file_private",
-        "type": "file",
-        "tier_access_level": "private"
-      },
-      {
-        "index": "studies_open",
-        "type": "studies_open",
-        "tier_access_level": "libre"
-      },
-      {
-        "index": "studies_controlled_access",
-        "type": "studies_controlled_access",
-        "tier_access_level": "private"
-      }
+        {
+            "index": "subject_regular",
+            "type": "subject",
+            "tier_access_level": "regular"
+        },
+        {
+            "index": "subject_private",
+            "type": "subject_private",
+            "tier_access_level": "private"
+        },
+        {
+            "index": "file_private",
+            "type": "file",
+            "tier_access_level": "private"
+        },
+        {
+            "index": "studies_open",
+            "type": "studies_open",
+            "tier_access_level": "libre"
+        },
+        {
+            "index": "studies_controlled_access",
+            "type": "studies_controlled_access",
+            "tier_access_level": "private"
+        }
     ]
-  }
+}

--- a/src/server/__tests__/testConfigFiles/test-index-scoped-tier-access.json
+++ b/src/server/__tests__/testConfigFiles/test-index-scoped-tier-access.json
@@ -3,27 +3,27 @@
       {
         "index": "subject_regular",
         "type": "subject",
-	    "tier_access_level": "regular"
+        "tier_access_level": "regular"
       },
       {
         "index": "subject_private",
         "type": "subject_private",
-	    "tier_access_level": "private"
+        "tier_access_level": "private"
       },
       {
         "index": "file_private",
         "type": "file",
-	    "tier_access_level": "private"
+        "tier_access_level": "private"
       },
       {
         "index": "studies_open",
         "type": "studies_open",
-	    "tier_access_level": "libre"
+        "tier_access_level": "libre"
       },
       {
         "index": "studies_controlled_access",
         "type": "studies_controlled_access",
-	    "tier_access_level": "private"
+        "tier_access_level": "private"
       }
     ]
   }

--- a/src/server/__tests__/testConfigFiles/test-index-scoped-tier-access.json
+++ b/src/server/__tests__/testConfigFiles/test-index-scoped-tier-access.json
@@ -1,0 +1,29 @@
+{
+    "indices": [
+      {
+        "index": "subject_regular",
+        "type": "subject",
+	    "tier_access_level": "regular"
+      },
+      {
+        "index": "subject_private",
+        "type": "subject_private",
+	    "tier_access_level": "private"
+      },
+      {
+        "index": "file_private",
+        "type": "file",
+	    "tier_access_level": "private"
+      },
+      {
+        "index": "studies_open",
+        "type": "studies_open",
+	    "tier_access_level": "libre"
+      },
+      {
+        "index": "studies_controlled_access",
+        "type": "studies_controlled_access",
+	    "tier_access_level": "private"
+      }
+    ]
+  }

--- a/src/server/__tests__/testConfigFiles/test-invalid-index-scoped-tier-access.json
+++ b/src/server/__tests__/testConfigFiles/test-invalid-index-scoped-tier-access.json
@@ -1,0 +1,14 @@
+{
+    "indices": [
+      {
+        "index": "subject_regular",
+        "type": "subject",
+	    "tier_access_level": "regular"
+      },
+      {
+        "index": "subject_private",
+        "type": "subject_private",
+	    "tier_access_level": "private____typo"
+      }
+    ]
+  }

--- a/src/server/__tests__/testConfigFiles/test-invalid-index-scoped-tier-access.json
+++ b/src/server/__tests__/testConfigFiles/test-invalid-index-scoped-tier-access.json
@@ -3,12 +3,12 @@
       {
         "index": "subject_regular",
         "type": "subject",
-	    "tier_access_level": "regular"
+        "tier_access_level": "regular"
       },
       {
         "index": "subject_private",
         "type": "subject_private",
-	    "tier_access_level": "private____typo"
+        "tier_access_level": "private____typo"
       }
     ]
   }

--- a/src/server/__tests__/testConfigFiles/test-invalid-index-scoped-tier-access.json
+++ b/src/server/__tests__/testConfigFiles/test-invalid-index-scoped-tier-access.json
@@ -1,14 +1,14 @@
 {
     "indices": [
-      {
-        "index": "subject_regular",
-        "type": "subject",
-        "tier_access_level": "regular"
-      },
-      {
-        "index": "subject_private",
-        "type": "subject_private",
-        "tier_access_level": "private____typo"
-      }
+        {
+            "index": "subject_regular",
+            "type": "subject",
+            "tier_access_level": "regular"
+        },
+        {
+            "index": "subject_private",
+            "type": "subject_private",
+            "tier_access_level": "private____typo"
+        }
     ]
-  }
+}

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -88,7 +88,7 @@ config.esConfig.indices.forEach((item) => {
   if (!item.tier_access_level && !config.tierAccessLevel) {
     throw new Error('Either set all index-scoped tiered-access levels or a site-wide tiered-access level.');
   }
-  if(!allowedTierAccessLevels.includes(item.tier_access_level)) {
+  if (!allowedTierAccessLevels.includes(item.tier_access_level)) {
     throw new Error(`tier_access_level invalid for index ${item.type}.`);
   }
   if (!item.tier_access_level) {

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -96,7 +96,7 @@ config.esConfig.indices.forEach((item) => {
 // If there is no site-wide TIER_ACCESS_LEVEL value and the indices all have settings,
 // empty out the default TIER_ACCESS_LEVEL from the config.
 if (allIndicesHaveTierAccessSettings && !process.env.TIER_ACCESS_LIMIT) {
-  delete config.tierAccessLimit;
+  delete config.tierAccessLevel;
 }
 
 // check whitelist is enabled

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -88,7 +88,7 @@ config.esConfig.indices.forEach((item) => {
   if (!item.tier_access_level && !config.tierAccessLevel) {
     throw new Error('Either set all index-scoped tiered-access levels or a site-wide tiered-access level.');
   }
-  if (!allowedTierAccessLevels.includes(item.tier_access_level)) {
+  if (item.tier_access_level && !allowedTierAccessLevels.includes(item.tier_access_level)) {
     throw new Error(`tier_access_level invalid for index ${item.type}.`);
   }
   if (!item.tier_access_level) {

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -55,10 +55,10 @@ if (process.env.GUPPY_PORT) {
   config.port = process.env.GUPPY_PORT;
 }
 
+const allowedTierAccessLevels = ['private', 'regular', 'libre'];
+
 if (process.env.TIER_ACCESS_LEVEL) {
-  if (process.env.TIER_ACCESS_LEVEL !== 'private'
-  && process.env.TIER_ACCESS_LEVEL !== 'regular'
-  && process.env.TIER_ACCESS_LEVEL !== 'libre') {
+  if (!allowedTierAccessLevels.includes(process.env.TIER_ACCESS_LEVEL)) {
     throw new Error(`Invalid TIER_ACCESS_LEVEL "${process.env.TIER_ACCESS_LEVEL}"`);
   }
   config.tierAccessLevel = process.env.TIER_ACCESS_LEVEL;
@@ -87,6 +87,9 @@ let allIndicesHaveTierAccessSettings = true;
 config.esConfig.indices.forEach((item) => {
   if (!item.tier_access_level && !config.tierAccessLevel) {
     throw new Error('Either set all index-scoped tiered-access levels or a site-wide tiered-access level.');
+  }
+  if(!allowedTierAccessLevels.includes(item.tier_access_level)) {
+    throw new Error(`tier_access_level invalid for index ${item.type}.`);
   }
   if (!item.tier_access_level) {
     allIndicesHaveTierAccessSettings = false;

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -93,8 +93,7 @@ config.esConfig.indices.forEach((item) => {
   }
 });
 
-// If there is no site-wide TIER_ACCESS_LEVEL value and the indices all have settings,
-// empty out the default TIER_ACCESS_LEVEL from the config.
+// If the indices all have settings, empty out the default site-wide TIER_ACCESS_LEVEL from the config.
 if (allIndicesHaveTierAccessSettings) {
   delete config.tierAccessLevel;
 }

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -93,7 +93,8 @@ config.esConfig.indices.forEach((item) => {
   }
 });
 
-// If the indices all have settings, empty out the default site-wide TIER_ACCESS_LEVEL from the config.
+// If the indices all have settings, empty out the default
+// site-wide TIER_ACCESS_LEVEL from the config.
 if (allIndicesHaveTierAccessSettings) {
   delete config.tierAccessLevel;
 }

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -73,9 +73,15 @@ if (process.env.ANALYZED_TEXT_FIELD_SUFFIX) {
   config.analyzedTextFieldSuffix = process.env.ANALYZED_TEXT_FIELD_SUFFIX;
 }
 
-// In cases where index-scoped tiered-access settings are not provided,
-// we fall back on the manifest-provided TIER_ACCESS_LEVEL value.
-// This allows for backwards-compatibility and flexibility between commons' use cases.
+// Either all indices should have explicit index-scoped tiered-access values or
+// the manifest should have a site-wide TIER_ACCESS_LEVEL value.
+// This approach is backwards-compatible with commons configured for past versions of tiered-access.
+config.esConfig.indices.forEach((item) => {
+  if (!item.tier_access_level && !process.env.TIER_ACCESS_LEVEL) {
+    throw new Error('Either set all index-scoped tiered-access levels or a site-wide tiered-access level.');
+  }
+});
+
 if (process.env.TIER_ACCESS_LEVEL) {
   if (process.env.TIER_ACCESS_LEVEL !== 'private'
   && process.env.TIER_ACCESS_LEVEL !== 'regular'

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -95,7 +95,7 @@ config.esConfig.indices.forEach((item) => {
 
 // If there is no site-wide TIER_ACCESS_LEVEL value and the indices all have settings,
 // empty out the default TIER_ACCESS_LEVEL from the config.
-if (allIndicesHaveTierAccessSettings && !process.env.TIER_ACCESS_LIMIT) {
+if (allIndicesHaveTierAccessSettings) {
   delete config.tierAccessLevel;
 }
 

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -55,6 +55,15 @@ if (process.env.GUPPY_PORT) {
   config.port = process.env.GUPPY_PORT;
 }
 
+if (process.env.TIER_ACCESS_LEVEL) {
+  if (process.env.TIER_ACCESS_LEVEL !== 'private'
+  && process.env.TIER_ACCESS_LEVEL !== 'regular'
+  && process.env.TIER_ACCESS_LEVEL !== 'libre') {
+    throw new Error(`Invalid TIER_ACCESS_LEVEL "${process.env.TIER_ACCESS_LEVEL}"`);
+  }
+  config.tierAccessLevel = process.env.TIER_ACCESS_LEVEL;
+}
+
 if (process.env.TIER_ACCESS_LIMIT) {
   config.tierAccessLimit = process.env.TIER_ACCESS_LIMIT;
 }
@@ -76,7 +85,7 @@ if (process.env.ANALYZED_TEXT_FIELD_SUFFIX) {
 // This approach is backwards-compatible with commons configured for past versions of tiered-access.
 let allIndicesHaveTierAccessSettings = true;
 config.esConfig.indices.forEach((item) => {
-  if (!item.tier_access_level && !process.env.TIER_ACCESS_LEVEL) {
+  if (!item.tier_access_level && !config.tierAccessLevel) {
     throw new Error('Either set all index-scoped tiered-access levels or a site-wide tiered-access level.');
   }
   if (!item.tier_access_level) {
@@ -86,17 +95,8 @@ config.esConfig.indices.forEach((item) => {
 
 // If there is no site-wide TIER_ACCESS_LEVEL value and the indices all have settings,
 // empty out the default TIER_ACCESS_LEVEL from the config.
-if (!process.env.TIER_ACCESS_LIMIT && allIndicesHaveTierAccessSettings) {
-  config.tierAccessLimit = process.env.TIER_ACCESS_LIMIT;
-}
-
-if (process.env.TIER_ACCESS_LEVEL) {
-  if (process.env.TIER_ACCESS_LEVEL !== 'private'
-  && process.env.TIER_ACCESS_LEVEL !== 'regular'
-  && process.env.TIER_ACCESS_LEVEL !== 'libre') {
-    throw new Error(`Invalid TIER_ACCESS_LEVEL "${process.env.TIER_ACCESS_LEVEL}"`);
-  }
-  config.tierAccessLevel = process.env.TIER_ACCESS_LEVEL;
+if (allIndicesHaveTierAccessSettings && !process.env.TIER_ACCESS_LIMIT) {
+  delete config.tierAccessLimit;
 }
 
 // check whitelist is enabled

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -10,7 +10,7 @@ const downloadRouter = async (req, res, next) => {
     type, filter, sort, fields, accessibility,
   } = req.body;
 
-  log.debug('[download] ', JSON.stringify(req.body, null, 4));
+  log.info('[download] ', JSON.stringify(req.body, null, 4));
   const esIndex = esInstance.getESIndexByType(type);
   const jwt = headerParser.parseJWT(req);
   const authHelper = await getAuthHelperInstance(jwt);
@@ -33,7 +33,7 @@ const downloadRouter = async (req, res, next) => {
         break;
       }
       case 'regular': {
-        log.debug('[download] regular commons');
+        log.info('[download] regular commons');
         if (accessibility === 'accessible') {
           appliedFilter = authHelper.applyAccessibleFilter(filter);
         } else {
@@ -58,12 +58,13 @@ const downloadRouter = async (req, res, next) => {
       default:
         throw new Error(`Invalid TIER_ACCESS_LEVEL "${tierAccessLevel}"`);
     }
-    log.debug('[download] applied filter for tierAccessLevel: ', tierAccessLevel);
+    log.info('[download] applied filter for tierAccessLevel: ', tierAccessLevel);
     const data = await esInstance.downloadData({
       esIndex, esType: type, filter: appliedFilter, sort, fields,
     });
     res.send(data);
   } catch (err) {
+    log.error(err)
     next(err);
   }
   return 0;

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -42,8 +42,8 @@ const downloadRouter = async (req, res, next) => {
           );
           // if requesting resources > allowed resources, return 401,
           if (outOfScopeResourceList.length > 0) {
-            log.debug('[download] requesting out-of-scope resources, return 401');
-            log.debug(`[download] the following resources are out-of-scope: [${outOfScopeResourceList.join(', ')}]`);
+            log.info('[download] requesting out-of-scope resources, return 401');
+            log.info(`[download] the following resources are out-of-scope: [${outOfScopeResourceList.join(', ')}]`);
             throw new CodedError(401, 'You don\'t have access to all the data you are querying. Try using \'accessibility: accessible\' in your query');
           } else { // else, go ahead download
             appliedFilter = filter;

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -11,9 +11,9 @@ const downloadRouter = async (req, res, next) => {
   } = req.body;
 
   log.debug('[download] ', JSON.stringify(req.body, null, 4));
-  const esIndex = esInstance.getESIndexConfigByType(type);
+  const esIndexConfig = esInstance.getESIndexConfigByType(type);
   const tierAccessLevel = (config.tierAccessLevel
-    ? config.tierAccessLevel : esIndex.tier_access_level);
+    ? config.tierAccessLevel : esIndexConfig.tier_access_level);
   const jwt = headerParser.parseJWT(req);
   const authHelper = await getAuthHelperInstance(jwt);
 
@@ -38,7 +38,7 @@ const downloadRouter = async (req, res, next) => {
           appliedFilter = authHelper.applyAccessibleFilter(filter);
         } else {
           const outOfScopeResourceList = await authHelper.getOutOfScopeResourceList(
-            esIndex.index, type, filter,
+            esIndexConfig.index, type, filter,
           );
           // if requesting resources > allowed resources, return 401,
           if (outOfScopeResourceList.length > 0) {
@@ -59,7 +59,7 @@ const downloadRouter = async (req, res, next) => {
         throw new Error(`Invalid TIER_ACCESS_LEVEL "${tierAccessLevel}"`);
     }
     const data = await esInstance.downloadData({
-      esIndex: esIndex.index, esType: type, filter: appliedFilter, sort, fields,
+      esIndex: esIndexConfig.index, esType: type, filter: appliedFilter, sort, fields,
     });
     res.send(data);
   } catch (err) {

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -12,6 +12,12 @@ const downloadRouter = async (req, res, next) => {
 
   log.info('[download] ', JSON.stringify(req.body, null, 4));
   const esIndex = esInstance.getESIndexByType(type);
+  log.info('[download] esIndex: ', esIndex);
+  log.info('[download] esIndex: ', JSON.stringify(esIndex));
+  log.info('[download] config.tierAccessLevel: ', config.tierAccessLevel);
+  log.info('[download] esIndex.tier_access_level: ', esIndex.tier_access_level);
+  const tierAccessLevel = (config.tierAccessLevel
+    ? config.tierAccessLevel : esIndex.tier_access_level);
   const jwt = headerParser.parseJWT(req);
   const authHelper = await getAuthHelperInstance(jwt);
 
@@ -25,8 +31,6 @@ const downloadRouter = async (req, res, next) => {
      *   b. if request contains only accessible resouces, return response
      * 3. if the data commons or the index is private, always return reponse without any auth check
      */
-    const tierAccessLevel = config.tierAccessLevel
-      ? config.tierAccessLevel : esIndex.tier_access_level;
     switch (tierAccessLevel) {
       case 'private': {
         appliedFilter = authHelper.applyAccessibleFilter(filter);
@@ -64,7 +68,7 @@ const downloadRouter = async (req, res, next) => {
     });
     res.send(data);
   } catch (err) {
-    log.error(err)
+    log.error(err);
     next(err);
   }
   return 0;

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -10,12 +10,8 @@ const downloadRouter = async (req, res, next) => {
     type, filter, sort, fields, accessibility,
   } = req.body;
 
-  log.info('[download] ', JSON.stringify(req.body, null, 4));
+  log.debug('[download] ', JSON.stringify(req.body, null, 4));
   const esIndex = esInstance.getESIndexConfigByType(type);
-  log.info('[download] esIndex: ', esIndex);
-  log.info('[download] esIndex: ', JSON.stringify(esIndex));
-  log.info('[download] config.tierAccessLevel: ', config.tierAccessLevel);
-  log.info('[download] esIndex.tier_access_level: ', esIndex.tier_access_level);
   const tierAccessLevel = (config.tierAccessLevel
     ? config.tierAccessLevel : esIndex.tier_access_level);
   const jwt = headerParser.parseJWT(req);
@@ -37,7 +33,7 @@ const downloadRouter = async (req, res, next) => {
         break;
       }
       case 'regular': {
-        log.info('[download] regular commons');
+        log.debug('[download] regular commons');
         if (accessibility === 'accessible') {
           appliedFilter = authHelper.applyAccessibleFilter(filter);
         } else {
@@ -46,8 +42,8 @@ const downloadRouter = async (req, res, next) => {
           );
           // if requesting resources > allowed resources, return 401,
           if (outOfScopeResourceList.length > 0) {
-            log.info('[download] requesting out-of-scope resources, return 401');
-            log.info(`[download] the following resources are out-of-scope: [${outOfScopeResourceList.join(', ')}]`);
+            log.debug('[download] requesting out-of-scope resources, return 401');
+            log.debug(`[download] the following resources are out-of-scope: [${outOfScopeResourceList.join(', ')}]`);
             throw new CodedError(401, 'You don\'t have access to all the data you are querying. Try using \'accessibility: accessible\' in your query');
           } else { // else, go ahead download
             appliedFilter = filter;
@@ -62,7 +58,6 @@ const downloadRouter = async (req, res, next) => {
       default:
         throw new Error(`Invalid TIER_ACCESS_LEVEL "${tierAccessLevel}"`);
     }
-    log.info('[download] applied filter for tierAccessLevel: ', tierAccessLevel);
     const data = await esInstance.downloadData({
       esIndex: esIndex.index, esType: type, filter: appliedFilter, sort, fields,
     });

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -11,7 +11,7 @@ const downloadRouter = async (req, res, next) => {
   } = req.body;
 
   log.info('[download] ', JSON.stringify(req.body, null, 4));
-  const esIndex = esInstance.getESIndexByType(type);
+  const esIndex = esInstance.getESIndexConfigByType(type);
   log.info('[download] esIndex: ', esIndex);
   log.info('[download] esIndex: ', JSON.stringify(esIndex));
   log.info('[download] config.tierAccessLevel: ', config.tierAccessLevel);
@@ -42,7 +42,7 @@ const downloadRouter = async (req, res, next) => {
           appliedFilter = authHelper.applyAccessibleFilter(filter);
         } else {
           const outOfScopeResourceList = await authHelper.getOutOfScopeResourceList(
-            esIndex, type, filter,
+            esIndex.index, type, filter,
           );
           // if requesting resources > allowed resources, return 401,
           if (outOfScopeResourceList.length > 0) {
@@ -64,7 +64,7 @@ const downloadRouter = async (req, res, next) => {
     }
     log.info('[download] applied filter for tierAccessLevel: ', tierAccessLevel);
     const data = await esInstance.downloadData({
-      esIndex, esType: type, filter: appliedFilter, sort, fields,
+      esIndex.index, esType: type, filter: appliedFilter, sort, fields,
     });
     res.send(data);
   } catch (err) {

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -64,7 +64,7 @@ const downloadRouter = async (req, res, next) => {
     }
     log.info('[download] applied filter for tierAccessLevel: ', tierAccessLevel);
     const data = await esInstance.downloadData({
-      esIndex.index, esType: type, filter: appliedFilter, sort, fields,
+      esIndex: esIndex.index, esType: type, filter: appliedFilter, sort, fields,
     });
     res.send(data);
   } catch (err) {

--- a/src/server/download.js
+++ b/src/server/download.js
@@ -21,11 +21,11 @@ const downloadRouter = async (req, res, next) => {
     let appliedFilter;
     /**
      * Tier access strategy for download endpoint:
-     * 1. if the data commons or the index is secure, add auth filter layer onto filter
+     * 1. if the data commons or the index is private, add auth filter layer onto filter
      * 2. if the data commons or the index is regular:
      *   a. if request contains out-of-access resource, return 401
      *   b. if request contains only accessible resouces, return response
-     * 3. if the data commons or the index is private, always return reponse without any auth check
+     * 3. if the data commons or the index is libre, always return reponse without any auth check
      */
     switch (tierAccessLevel) {
       case 'private': {

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -319,6 +319,20 @@ class ES {
   }
 
   /**
+   * Get es index config by es index name
+   * Throw 400 error if there's no existing es index of that name
+   * @param {string} esIndexName
+   */
+  getESIndexConfigByName(esIndexName) {
+    const indexConfig = this.config.indices.find((i) => i.index === esIndexName);
+    if (indexConfig) return indexConfig;
+    throw new CodedError(
+      400,
+      `Invalid es index name: "${esIndexName}"`,
+    );
+  }
+
+  /**
    * Get all es indices and their alias
    */
   getAllESIndices() {

--- a/src/server/es/index.js
+++ b/src/server/es/index.js
@@ -319,6 +319,20 @@ class ES {
   }
 
   /**
+   * Get es indexConfig by es type
+   * Throw 400 error if there's no existing es type
+   * @param {string} esType
+   */
+  getESIndexConfigByType(esType) {
+    const index = this.config.indices.find((i) => i.type === esType);
+    if (index) return index;
+    throw new CodedError(
+      400,
+      `Invalid es type: "${esType}"`,
+    );
+  }
+
+  /**
    * Get es index config by es index name
    * Throw 400 error if there's no existing es index of that name
    * @param {string} esIndexName

--- a/src/server/middlewares/authMiddleware/index.js
+++ b/src/server/middlewares/authMiddleware/index.js
@@ -3,7 +3,7 @@ import authMWResolver from './resolvers';
 
 // apply this middleware to all es types' data/aggregation resolvers
 const typeMapping = config.esConfig.indices.reduce((acc, item) => {
-  acc[item.index] = authMWResolver;
+  acc[item.type] = authMWResolver;
   return acc;
 }, {});
 const authMiddleware = {

--- a/src/server/middlewares/authMiddleware/index.js
+++ b/src/server/middlewares/authMiddleware/index.js
@@ -3,7 +3,7 @@ import authMWResolver from './resolvers';
 
 // apply this middleware to all es types' data/aggregation resolvers
 const typeMapping = config.esConfig.indices.reduce((acc, item) => {
-  acc[item.type] = authMWResolver;
+  acc[item.index] = authMWResolver;
   return acc;
 }, {});
 const authMiddleware = {

--- a/src/server/middlewares/authMiddleware/resolvers.js
+++ b/src/server/middlewares/authMiddleware/resolvers.js
@@ -1,7 +1,16 @@
 import log from '../../logger';
 import config from '../../config';
+import esInstance from '../../es/index';
 
 const authMWResolver = async (resolve, root, args, context, info) => {
+  // Assert that either this index is "private" access or
+  // that the index has no setting and site-wide config is "private".
+  const indexConfig = esInstance.getESIndexConfigByName(esIndex);
+  const indexIsPrivateAccess = indexConfig.tier_access_level === 'private';
+  const tierAccessPrivateAndNotIndexScoped = !indexConfig.tier_access_level && config.tierAccessLevel === 'private';
+  assert(indexIsPrivateAccess || tierAccessPrivateAndNotIndexScoped, 'Auth middleware layer only for "private" tier access level');
+
+
   const { authHelper } = context;
 
   // if mock arborist endpoint, just skip auth middleware

--- a/src/server/middlewares/authMiddleware/resolvers.js
+++ b/src/server/middlewares/authMiddleware/resolvers.js
@@ -1,16 +1,7 @@
 import log from '../../logger';
 import config from '../../config';
-import esInstance from '../../es/index';
 
 const authMWResolver = async (resolve, root, args, context, info) => {
-  // Assert that either this index is "private" access or
-  // that the index has no setting and site-wide config is "private".
-  const indexConfig = esInstance.getESIndexConfigByName(esIndex);
-  const indexIsPrivateAccess = indexConfig.tier_access_level === 'private';
-  const tierAccessPrivateAndNotIndexScoped = !indexConfig.tier_access_level && config.tierAccessLevel === 'private';
-  assert(indexIsPrivateAccess || tierAccessPrivateAndNotIndexScoped, 'Auth middleware layer only for "private" tier access level');
-
-
   const { authHelper } = context;
 
   // if mock arborist endpoint, just skip auth middleware

--- a/src/server/middlewares/index.js
+++ b/src/server/middlewares/index.js
@@ -1,6 +1,6 @@
 import authMiddleware from './authMiddleware';
 import tierAccessMiddleware from './tierAccessMiddleware';
-// import perIndexTierAccessMiddleware from './perIndexTierAccessMiddleware';
+import perIndexTierAccessMiddleware from './perIndexTierAccessMiddleware';
 import config from '../config';
 
 const middlewares = [];
@@ -17,7 +17,7 @@ switch (config.tierAccessLevel) {
     middlewares.push(authMiddleware);
     break;
   default:
-    // middlewares.push(perIndexTierAccessMiddleware);
+    middlewares.push(perIndexTierAccessMiddleware);
     break;
 }
 export default middlewares;

--- a/src/server/middlewares/index.js
+++ b/src/server/middlewares/index.js
@@ -17,7 +17,7 @@ switch (config.tierAccessLevel) {
     middlewares.push(authMiddleware);
     break;
   default:
-    middlewares.push(perIndexTierAccessMiddleware);
+    // middlewares.push(perIndexTierAccessMiddleware);
     break;
 }
 export default middlewares;

--- a/src/server/middlewares/index.js
+++ b/src/server/middlewares/index.js
@@ -9,14 +9,18 @@ const middlewares = [];
 // we apply ES-index-specific tiered access settings.
 switch (config.tierAccessLevel) {
   case 'libre':
+    console.log('[Server] applying libre middleware.');
     break;
   case 'regular':
+    console.log('[Server] applying site-wide regular middleware.');
     middlewares.push(tierAccessMiddleware);
     break;
   case 'private':
+    console.log('[Server] applying site-wide private middleware.');
     middlewares.push(authMiddleware);
     break;
   default:
+    console.log('[Server] applying index-scoped middleware.');
     middlewares.push(perIndexTierAccessMiddleware);
     break;
 }

--- a/src/server/middlewares/index.js
+++ b/src/server/middlewares/index.js
@@ -2,6 +2,7 @@ import authMiddleware from './authMiddleware';
 import tierAccessMiddleware from './tierAccessMiddleware';
 import perIndexTierAccessMiddleware from './perIndexTierAccessMiddleware';
 import config from '../config';
+import log from '../logger';
 
 const middlewares = [];
 
@@ -9,18 +10,18 @@ const middlewares = [];
 // we apply ES-index-specific tiered access settings.
 switch (config.tierAccessLevel) {
   case 'libre':
-    console.log('[Server] applying libre middleware.');
+    log.info('[Server] applying libre middleware across indices.');
     break;
   case 'regular':
-    console.log('[Server] applying site-wide regular middleware.');
+    log.info('[Server] applying regular middleware across indices.');
     middlewares.push(tierAccessMiddleware);
     break;
   case 'private':
-    console.log('[Server] applying site-wide private middleware.');
+    log.info('[Server] applying private middleware across indices.');
     middlewares.push(authMiddleware);
     break;
   default:
-    console.log('[Server] applying index-scoped middleware.');
+    log.info('[Server] applying index-scoped middleware.');
     middlewares.push(perIndexTierAccessMiddleware);
     break;
 }

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -6,12 +6,14 @@ import { tierAccessResolver, hideNumberResolver } from '../tierAccessMiddleware/
 const queryTypeMapping = {};
 const aggsTypeMapping = {};
 const totalCountTypeMapping = {};
+let atLeastOneIndexIsRegularAccess = false;
 
 config.esConfig.indices.forEach((item) => {
   if (item.tier_access_level === 'private') {
     queryTypeMapping[item.type] = authMWResolver;
     aggsTypeMapping[item.type] = authMWResolver;
   } else if (item.tier_access_level === 'regular') {
+    atLeastOneIndexIsRegularAccess = true;
     queryTypeMapping[item.type] = tierAccessResolver({
       isRawDataQuery: true,
       esType: item.type,
@@ -35,12 +37,16 @@ const perIndexTierAccessMiddleware = {
     ...aggsTypeMapping,
   },
   ...totalCountTypeMapping,
-  RegularAccessHistogramForNumber: {
-    histogram: hideNumberResolver(false),
-  },
-  RegularAccessHistogramForString: {
-    histogram: hideNumberResolver(false),
-  },
 };
+
+if (atLeastOneIndexIsRegularAccess) {
+  perIndexTierAccessMiddleware.RegularAccessHistogramForNumber = {
+    histogram: hideNumberResolver(false),
+  };
+
+  perIndexTierAccessMiddleware.RegularAccessHistogramForString = {
+    histogram: hideNumberResolver(false),
+  };
+}
 
 export default perIndexTierAccessMiddleware;

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -24,8 +24,6 @@ config.esConfig.indices.forEach((item) => {
     };
   } else if (item.tier_access_level === 'libre') {
     // No additional resolvers necessary
-  } else {
-    throw new Error(`tier_access_level invalid for index ${item.type}. Either set all index-scoped tiered-access levels or a site-wide tiered-access level.`);
   }
 }, {});
 

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -5,7 +5,7 @@ import { tierAccessResolver, hideNumberResolver } from '../tierAccessMiddleware/
 
 const queryTypeMapping = {};
 const aggsTypeMapping = {};
-const histogramTypeMapping = {};
+const histogramForNumberTypeMapping = {};
 const histogramForStringTypeMapping = {};
 const totalCountTypeMapping = {};
 
@@ -24,8 +24,8 @@ config.esConfig.indices.forEach((item) => {
     totalCountTypeMapping[aggregationName] = {
       _totalCount: hideNumberResolver(true),
     };
-    histogramTypeMapping[item.type] = { histogram: hideNumberResolver(false) };
-    histogramForStringTypeMapping[item.type] = { histogram: hideNumberResolver(false) };
+    histogramForNumberTypeMapping[item.type] = hideNumberResolver(false);
+    histogramForStringTypeMapping[item.type] = hideNumberResolver(false);
   } else if (item.tier_access_level === 'libre') {
     // No additional resolvers necessary
   } else {
@@ -41,10 +41,10 @@ const perIndexTierAccessMiddleware = {
     ...aggsTypeMapping,
   },
   ...totalCountTypeMapping,
-  HistogramForNumber: {
-    ...histogramTypeMapping,
+  RegularAccessHistogramForNumber: {
+    ...histogramForNumberTypeMapping,
   },
-  HistogramForString: {
+  RegularAccessHistogramForString: {
     ...histogramForStringTypeMapping,
   },
 };

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -5,8 +5,6 @@ import { tierAccessResolver, hideNumberResolver } from '../tierAccessMiddleware/
 
 const queryTypeMapping = {};
 const aggsTypeMapping = {};
-const histogramForNumberTypeMapping = {};
-const histogramForStringTypeMapping = {};
 const totalCountTypeMapping = {};
 
 config.esConfig.indices.forEach((item) => {
@@ -24,8 +22,6 @@ config.esConfig.indices.forEach((item) => {
     totalCountTypeMapping[aggregationName] = {
       _totalCount: hideNumberResolver(true),
     };
-    histogramForNumberTypeMapping[item.type] = hideNumberResolver(false);
-    histogramForStringTypeMapping[item.type] = hideNumberResolver(false);
   } else if (item.tier_access_level === 'libre') {
     // No additional resolvers necessary
   } else {
@@ -42,10 +38,10 @@ const perIndexTierAccessMiddleware = {
   },
   ...totalCountTypeMapping,
   RegularAccessHistogramForNumber: {
-    ...histogramForNumberTypeMapping,
+    histogram: hideNumberResolver(false),
   },
   RegularAccessHistogramForString: {
-    ...histogramForStringTypeMapping,
+    histogram: hideNumberResolver(false),
   },
 };
 

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -3,12 +3,6 @@ import { firstLetterUpperCase } from '../../utils/utils';
 import authMWResolver from '../authMiddleware/resolvers';
 import { tierAccessResolver, hideNumberResolver } from '../tierAccessMiddleware/resolvers';
 
-const isPrivate = (index) => index.tier_access_level === 'private';
-const isRegular = (index) => index.tier_access_level === 'regular';
-const isLibre = (index) => index.tier_access_level === 'libre';
-const atLeastOneIndexIsPrivate = config.esConfig.indices.some(isPrivate);
-const atLeastOneIndexIsRegular = config.esConfig.indices.some(isRegular);
-
 const queryTypeMapping = {};
 const aggsTypeMapping = {};
 const histogramTypeMapping = {};

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -15,9 +15,9 @@ config.esConfig.indices.forEach((item) => {
     queryTypeMapping[item.type] = tierAccessResolver({
       isRawDataQuery: true,
       esType: item.type,
-      esIndex: item.type,
+      esIndex: item.index,
     });
-    aggsTypeMapping[item.type] = tierAccessResolver({ esType: item.type, esIndex: item.type });
+    aggsTypeMapping[item.type] = tierAccessResolver({ esType: item.type, esIndex: item.index });
     const aggregationName = `${firstLetterUpperCase(item.type)}Aggregation`;
     totalCountTypeMapping[aggregationName] = {
       _totalCount: hideNumberResolver(true),

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -7,7 +7,7 @@ const queryIndexMapping = {};
 const aggsIndexMapping = {};
 const histogramIndexMapping = {};
 const histogramForStringIndexMapping = {};
-const totalCountIndexMapping = {};
+const totalCountTypeMapping = {};
 
 config.esConfig.indices.forEach((item) => {
   if (item.tier_access_level === 'private') {
@@ -21,7 +21,7 @@ config.esConfig.indices.forEach((item) => {
     });
     aggsIndexMapping[item.index] = tierAccessResolver({ esType: item.type, esIndex: item.index });
     const aggregationName = `${firstLetterUpperCase(item.type)}Aggregation`;
-    totalCountIndexMapping[aggregationName] = {
+    totalCountTypeMapping[aggregationName] = {
       _totalCount: hideNumberResolver(true),
     };
     histogramIndexMapping[item.index] = { histogram: hideNumberResolver(false) };
@@ -40,7 +40,7 @@ const perIndexTierAccessMiddleware = {
   Aggregation: {
     ...aggsIndexMapping,
   },
-  ...totalCountIndexMapping,
+  ...totalCountTypeMapping,
   HistogramForNumber: {
     ...histogramIndexMapping,
   },

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -9,7 +9,7 @@ const histogramIndexMapping = {};
 const histogramForStringIndexMapping = {};
 const totalCountIndexMapping = {};
 
-config.esConfig.indices.reduce((acc, item) => {
+config.esConfig.indices.forEach((item) => {
   if (item.tier_access_level === 'private') {
     queryIndexMapping[item.index] = authMWResolver;
     aggsIndexMapping[item.index] = authMWResolver;
@@ -29,9 +29,8 @@ config.esConfig.indices.reduce((acc, item) => {
   } else if (item.tier_access_level === 'libre') {
     // No additional resolvers necessary
   } else {
-    throw new Error(`tier_access_level invalid for index ${item.index}. Please set index-scoped or site-wide tiered-access levels.`);
+    throw new Error(`tier_access_level invalid for index ${item.index}. Either set all index-scoped tiered-access levels or a site-wide tiered-access level.`);
   }
-  return acc;
 }, {});
 
 const perIndexTierAccessMiddleware = {

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -3,6 +3,12 @@ import { firstLetterUpperCase } from '../../utils/utils';
 import authMWResolver from '../authMiddleware/resolvers';
 import { tierAccessResolver, hideNumberResolver } from '../tierAccessMiddleware/resolvers';
 
+const isPrivate = (index) => index.tier_access_level === 'private';
+const isRegular = (index) => index.tier_access_level === 'regular';
+const isLibre = (index) => index.tier_access_level === 'libre';
+const atLeastOneIndexIsPrivate = config.esConfig.indices.some(isPrivate);
+const atLeastOneIndexIsRegular = config.esConfig.indices.some(isRegular);
+
 const queryTypeMapping = {};
 const aggsTypeMapping = {};
 const histogramTypeMapping = {};

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -24,9 +24,8 @@ config.esConfig.indices.forEach((item) => {
     totalCountTypeMapping[aggregationName] = {
       _totalCount: hideNumberResolver(true),
     };
-  } else if (item.tier_access_level === 'libre') {
-    // No additional resolvers necessary
   }
+  // No additional resolvers necessary for tier_access_level == 'libre'
 }, {});
 
 const perIndexTierAccessMiddleware = {

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -1,0 +1,53 @@
+import config from '../../config';
+import { firstLetterUpperCase } from '../../utils/utils';
+import authMWResolver from '../authMiddleware/resolvers';
+import { tierAccessResolver, hideNumberResolver } from '../tierAccessMiddleware/resolvers';
+
+const queryIndexMapping = {};
+const aggsIndexMapping = {};
+const histogramIndexMapping = {};
+const histogramForStringIndexMapping = {};
+const totalCountIndexMapping = {};
+
+config.esConfig.indices.reduce((acc, item) => {
+  if (item.tier_access_level === 'private') {
+    queryIndexMapping[item.index] = authMWResolver;
+    aggsIndexMapping[item.index] = authMWResolver;
+  } else if (item.tier_access_level === 'regular') {
+    queryIndexMapping[item.index] = tierAccessResolver({
+      isRawDataQuery: true,
+      esType: item.type,
+      esIndex: item.index,
+    });
+    aggsIndexMapping[item.index] = tierAccessResolver({ esType: item.type, esIndex: item.index });
+    const aggregationName = `${firstLetterUpperCase(item.type)}Aggregation`;
+    totalCountIndexMapping[aggregationName] = {
+      _totalCount: hideNumberResolver(true),
+    };
+    histogramIndexMapping[item.index] = { histogram: hideNumberResolver(false) };
+    histogramForStringIndexMapping[item.index] = { histogram: hideNumberResolver(false) };
+  } else if (item.tier_access_level === 'libre') {
+    // No additional resolvers necessary
+  } else {
+    throw new Error(`tier_access_level invalid for index ${item.index}. Please set index-scoped or site-wide tiered-access levels.`);
+  }
+  return acc;
+}, {});
+
+const perIndexTierAccessMiddleware = {
+  Query: {
+    ...queryIndexMapping,
+  },
+  Aggregation: {
+    ...aggsIndexMapping,
+  },
+  ...totalCountIndexMapping,
+  HistogramForNumber: {
+    ...histogramIndexMapping,
+  },
+  HistogramForString: {
+    ...histogramForStringIndexMapping,
+  },
+};
+
+export default perIndexTierAccessMiddleware;

--- a/src/server/middlewares/tierAccessMiddleware/index.js
+++ b/src/server/middlewares/tierAccessMiddleware/index.js
@@ -3,16 +3,16 @@ import { firstLetterUpperCase } from '../../utils/utils';
 import { tierAccessResolver, hideNumberResolver } from './resolvers';
 
 // apply this middleware to all es types' data/aggregation resolvers
-const queryIndexMapping = {};
-const aggsIndexMapping = {};
+const queryTypeMapping = {};
+const aggsTypeMapping = {};
 const totalCountTypeMapping = {};
 config.esConfig.indices.forEach((item) => {
-  queryIndexMapping[item.index] = tierAccessResolver({
+  queryTypeMapping[item.type] = tierAccessResolver({
     isRawDataQuery: true,
     esType: item.type,
     esIndex: item.index,
   });
-  aggsIndexMapping[item.index] = tierAccessResolver({ esType: item.type, esIndex: item.index });
+  aggsTypeMapping[item.type] = tierAccessResolver({ esType: item.type, esIndex: item.index });
   const aggregationName = `${firstLetterUpperCase(item.type)}Aggregation`;
   totalCountTypeMapping[aggregationName] = {
     _totalCount: hideNumberResolver(true),
@@ -20,10 +20,10 @@ config.esConfig.indices.forEach((item) => {
 });
 const tierAccessMiddleware = {
   Query: {
-    ...queryIndexMapping,
+    ...queryTypeMapping,
   },
   Aggregation: {
-    ...aggsIndexMapping,
+    ...aggsTypeMapping,
   },
   ...totalCountTypeMapping,
   HistogramForNumber: {

--- a/src/server/middlewares/tierAccessMiddleware/index.js
+++ b/src/server/middlewares/tierAccessMiddleware/index.js
@@ -3,15 +3,16 @@ import { firstLetterUpperCase } from '../../utils/utils';
 import { tierAccessResolver, hideNumberResolver } from './resolvers';
 
 // apply this middleware to all es types' data/aggregation resolvers
-const queryTypeMapping = {};
-const aggsTypeMapping = {};
+const queryIndexMapping = {};
+const aggsIndexMapping = {};
 const totalCountTypeMapping = {};
 config.esConfig.indices.forEach((item) => {
-  queryTypeMapping[item.type] = tierAccessResolver({
+  queryIndexMapping[item.index] = tierAccessResolver({
     isRawDataQuery: true,
     esType: item.type,
+    esIndex: item.index,
   });
-  aggsTypeMapping[item.type] = tierAccessResolver({ esType: item.type });
+  aggsIndexMapping[item.index] = tierAccessResolver({ esType: item.type, esIndex: item.index });
   const aggregationName = `${firstLetterUpperCase(item.type)}Aggregation`;
   totalCountTypeMapping[aggregationName] = {
     _totalCount: hideNumberResolver(true),
@@ -19,10 +20,10 @@ config.esConfig.indices.forEach((item) => {
 });
 const tierAccessMiddleware = {
   Query: {
-    ...queryTypeMapping,
+    ...queryIndexMapping,
   },
   Aggregation: {
-    ...aggsTypeMapping,
+    ...aggsIndexMapping,
   },
   ...totalCountTypeMapping,
   HistogramForNumber: {

--- a/src/server/middlewares/tierAccessMiddleware/resolvers.js
+++ b/src/server/middlewares/tierAccessMiddleware/resolvers.js
@@ -41,13 +41,13 @@ export const tierAccessResolver = (
   },
 ) => async (resolve, root, args, context, info) => {
   try {
-    // Assert that either this index is "regular" access or 
+    // Assert that either this index is "regular" access or
     // that the index has no setting and site-wide config is "regular".
     const indexConfig = esInstance.getESIndexConfigByName(esIndex);
-    const indexIsRegularAccess = indexConfig.tier_access_level == 'regular';
+    const indexIsRegularAccess = indexConfig.tier_access_level === 'regular';
     const tierAccessRegularAndNotIndexScoped = !indexConfig.tier_access_level && config.tierAccessLevel === 'regular';
     assert(indexIsRegularAccess || tierAccessRegularAndNotIndexScoped, 'Tier access middleware layer only for "regular" tier access level');
-    
+
     const { authHelper } = context;
     const { filter, filterSelf, accessibility } = args;
 

--- a/src/server/middlewares/tierAccessMiddleware/resolvers.js
+++ b/src/server/middlewares/tierAccessMiddleware/resolvers.js
@@ -45,8 +45,8 @@ export const tierAccessResolver = (
     // that the index has no setting and site-wide config is "regular".
     const indexConfig = esInstance.getESIndexConfigByName(esIndex);
     const indexIsRegularAccess = indexConfig.tier_access_level === 'regular';
-    const tierAccessRegularAndNotIndexScoped = !indexConfig.tier_access_level && config.tierAccessLevel === 'regular';
-    assert(indexIsRegularAccess || tierAccessRegularAndNotIndexScoped, 'Tier access middleware layer only for "regular" tier access level');
+    const siteIsRegularAccess = config.tierAccessLevel === 'regular';
+    assert(indexIsRegularAccess || siteIsRegularAccess, 'Tier access middleware layer only for "regular" tier access level');
 
     const { authHelper } = context;
     const { filter, filterSelf, accessibility } = args;

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -265,6 +265,13 @@ const getResolver = (esConfig, esInstance) => {
     HistogramForString: {
       histogram: textHistogramResolver,
     },
+    RegularAccessHistogramForNumber: {
+      histogram: numericHistogramResolver,
+      asTextHistogram: textHistogramResolver,
+    },
+    RegularAccessHistogramForString: {
+      histogram: textHistogramResolver,
+    },
     Mapping: {
       ...mappingResolvers,
     },

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -55,19 +55,7 @@ const getAggsHistogramName = (gqlType) => {
   return gqlTypeToAggsHistogramName[gqlType];
 };
 
-const getObjNameFromESIndex = (esIndex) => {
-  let esTypeObjName = firstLetterUpperCase(esIndex);
-  // Choosing to replace hyphens with the string "_DASH_".
-  // It's self-documenting, lends well to readability, and the
-  // likelihood of a user naming an ES index with the string _DASH_ is low.
-  esTypeObjName = esTypeObjName.replace(/-/g, '_DASH_');
-  return esTypeObjName;
-};
-
-/* eslint-disable no-unused-vars */
 const getQuerySchemaForType = (esType) => {
-  // This function is now unused in favor of an
-  // index-scoped query schema.
   const esTypeObjName = firstLetterUpperCase(esType);
   return `${esType} (
     offset: Int,
@@ -77,19 +65,6 @@ const getQuerySchemaForType = (esType) => {
     accessibility: Accessibility=all,
     format: Format=json,
     ): [${esTypeObjName}]`;
-};
-
-const getQuerySchemaForIndex = (esIndex) => {
-  // This function helps build an index-scoped query schema
-  // so as to scope middleware by index rather than type.
-  const esIndexObjName = getObjNameFromESIndex(esIndex);
-  return `${esIndexObjName} (
-    offset: Int, 
-    first: Int,
-    filter: JSON,
-    sort: JSON,
-    accessibility: Accessibility=all,
-    ): [${esIndexObjName}]`;
 };
 
 const getFieldGQLTypeMapForProperties = (esInstance, esIndex, properties) => {
@@ -188,7 +163,7 @@ const getAggregationSchemaForOneIndex = (esInstance, esIndex, esType) => {
 
 export const getQuerySchema = (esConfig) => `
     type Query {
-      ${esConfig.indices.map((cfg) => getQuerySchemaForIndex(cfg.index)).join('\n')}
+      ${esConfig.indices.map((cfg) => getQuerySchemaForType(cfg.type)).join('\n')}
       _aggregation: Aggregation
       _mapping: Mapping
     }

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -147,11 +147,11 @@ const getAggregationType = (entry) => {
 };
 
 const getAggregationSchemaForOneIndex = (esInstance, esDict) => {
-  const esIndex = esDict.type;
+  const esIndex = esDict.index;
   const esType = esDict.type;
   let histogramTypePrefix = '';
   // eslint-disable-next-line no-console
-  console.log('>>>>> inside getAggregationSchemaForOneIndex; esIndex: ', esIndex);
+  console.log('>>>>> inside getAggregationSchemaForOneIndex; esIndex: ', esDict);
   if (Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular') {
     histogramTypePrefix = 'RegularAccess';
   }
@@ -197,7 +197,7 @@ export const getAggregationSchema = (esConfig) => `
  * For each level of nested field a new type in schema is created.
  */
 const getAggregationSchemaForOneNestedIndex = (esInstance, esDict) => {
-  const esIndex = esDict.type;
+  const esIndex = esDict.index;
   const fieldGQLTypeMap = getFieldGQLTypeMapForOneIndex(esInstance, esIndex);
   const fieldAggsNestedTypeMap = fieldGQLTypeMap.filter((f) => f.esType === 'nested');
   let histogramTypePrefix = '';

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -58,14 +58,15 @@ const getAggsHistogramName = (gqlType) => {
 const getObjNameFromESIndex = (esIndex) => {
   let esTypeObjName = firstLetterUpperCase(esIndex);
   // Choosing to replace hyphens with the string "_DASH_".
-  // It's self-documenting, lends well to readability, and the 
-  // likelihood of a user naming an ES index with the string _DASH_ is low. 
+  // It's self-documenting, lends well to readability, and the
+  // likelihood of a user naming an ES index with the string _DASH_ is low.
   esTypeObjName = esTypeObjName.replaceAll('-', '_DASH_');
   return esTypeObjName;
 };
 
+/* eslint-disable no-unused-vars */
 const getQuerySchemaForType = (esType) => {
-  // This function is now unused in favor of an 
+  // This function is now unused in favor of an
   // index-scoped query schema.
   const esTypeObjName = firstLetterUpperCase(esType);
   return `${esType} (
@@ -88,7 +89,7 @@ const getQuerySchemaForIndex = (esIndex) => {
     filter: JSON,
     sort: JSON,
     accessibility: Accessibility=all,
-    ): [${esTypeObjName}]`;
+    ): [${esIndexObjName}]`;
 };
 
 const getFieldGQLTypeMapForProperties = (esInstance, esIndex, properties) => {

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -150,8 +150,6 @@ const getAggregationSchemaForOneIndex = (esInstance, esDict) => {
   const esIndex = esDict.index;
   const esType = esDict.type;
   let histogramTypePrefix = '';
-  // eslint-disable-next-line no-console
-  console.log('>>>>> inside getAggregationSchemaForOneIndex; esIndex: ', esDict);
   if (Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular') {
     histogramTypePrefix = 'RegularAccess';
   }

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -149,15 +149,13 @@ const getAggregationType = (entry) => {
 const getAggregationSchemaForOneIndex = (esInstance, esDict) => {
   const esIndex = esDict.index;
   const esType = esDict.type;
-  let histogramTypePrefix = '';
-  if (Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular') {
-    histogramTypePrefix = 'RegularAccess';
-  }
+  const histogramTypePrefix = 'RegularAccess';
+  const includeHistogramPrefix = Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular';
   const esTypeObjName = firstLetterUpperCase(esType);
   const fieldGQLTypeMap = getFieldGQLTypeMapForOneIndex(esInstance, esIndex);
   const fieldAggsTypeMap = fieldGQLTypeMap.filter((f) => f.esType !== 'nested').map((entry) => ({
     field: entry.field,
-    aggType: histogramTypePrefix + getAggsHistogramName(entry.type),
+    aggType: (includeHistogramPrefix ? histogramTypePrefix : '') + getAggsHistogramName(entry.type),
   }));
   const fieldAggsNestedTypeMap = fieldGQLTypeMap.filter((f) => f.esType === 'nested');
   return `type ${esTypeObjName}Aggregation {
@@ -198,11 +196,8 @@ const getAggregationSchemaForOneNestedIndex = (esInstance, esDict) => {
   const esIndex = esDict.index;
   const fieldGQLTypeMap = getFieldGQLTypeMapForOneIndex(esInstance, esIndex);
   const fieldAggsNestedTypeMap = fieldGQLTypeMap.filter((f) => f.esType === 'nested');
-  let histogramTypePrefix = '';
-  if (Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular') {
-    histogramTypePrefix = 'RegularAccess';
-  }
-
+  const histogramTypePrefix = 'RegularAccess';
+  const includeHistogramPrefix = Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular';
   let AggsNestedTypeSchema = '';
   while (fieldAggsNestedTypeMap.length > 0) {
     const entry = fieldAggsNestedTypeMap.shift();
@@ -218,7 +213,7 @@ const getAggregationSchemaForOneNestedIndex = (esInstance, esDict) => {
       ${propsKey}: NestedHistogramFor${firstLetterUpperCase(propsKey)}`;
         }
         return `
-    ${propsKey}: ${histogramTypePrefix + getAggsHistogramName(esgqlTypeMapping[entryType])}`;
+    ${propsKey}: ${(includeHistogramPrefix ? histogramTypePrefix : '') + getAggsHistogramName(esgqlTypeMapping[entryType])}`;
       })}
 }`;
     }
@@ -232,12 +227,9 @@ export const getAggregationSchemaForEachType = (esConfig, esInstance) => esConfi
 export const getAggregationSchemaForEachNestedType = (esConfig, esInstance) => esConfig.indices.map((cfg) => getAggregationSchemaForOneNestedIndex(esInstance, cfg)).join('\n');
 
 const getNumberHistogramSchema = (isRegularAccess) => {
-  let histogramTypePrefix = '';
-  if (isRegularAccess) {
-    histogramTypePrefix = 'RegularAccess';
-  }
+  const histogramTypePrefix = 'RegularAccess';
   return `
-    type ${histogramTypePrefix + EnumAggsHistogramName.HISTOGRAM_FOR_NUMBER} {
+    type ${(isRegularAccess ? histogramTypePrefix : '') + EnumAggsHistogramName.HISTOGRAM_FOR_NUMBER} {
       histogram(
         rangeStart: Int,
         rangeEnd: Int,
@@ -250,12 +242,9 @@ const getNumberHistogramSchema = (isRegularAccess) => {
 };
 
 const getTextHistogramSchema = (isRegularAccess) => {
-  let histogramTypePrefix = '';
-  if (isRegularAccess) {
-    histogramTypePrefix = 'RegularAccess';
-  }
+  const histogramTypePrefix = 'RegularAccess';
   return `
-    type ${histogramTypePrefix + EnumAggsHistogramName.HISTOGRAM_FOR_STRING} {
+    type ${(isRegularAccess ? histogramTypePrefix : '') + EnumAggsHistogramName.HISTOGRAM_FOR_STRING} {
       histogram: [BucketsForNestedStringAgg]
     }
   `;

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -147,11 +147,15 @@ const getAggregationType = (entry) => {
 };
 
 const getAggregationSchemaForOneIndex = (esInstance, esIndex, esType) => {
+  let histogramTypePrefix = '';
+  if (esIndex.tier_access_level === 'regular') {
+    histogramTypePrefix = 'RegularAccess';
+  }
   const esTypeObjName = firstLetterUpperCase(esType);
   const fieldGQLTypeMap = getFieldGQLTypeMapForOneIndex(esInstance, esIndex);
   const fieldAggsTypeMap = fieldGQLTypeMap.filter((f) => f.esType !== 'nested').map((entry) => ({
     field: entry.field,
-    aggType: getAggsHistogramName(entry.type),
+    aggType: histogramTypePrefix + getAggsHistogramName(entry.type),
   }));
   const fieldAggsNestedTypeMap = fieldGQLTypeMap.filter((f) => f.esType === 'nested');
   return `type ${esTypeObjName}Aggregation {
@@ -191,6 +195,10 @@ export const getAggregationSchema = (esConfig) => `
 const getAggregationSchemaForOneNestedIndex = (esInstance, esIndex) => {
   const fieldGQLTypeMap = getFieldGQLTypeMapForOneIndex(esInstance, esIndex);
   const fieldAggsNestedTypeMap = fieldGQLTypeMap.filter((f) => f.esType === 'nested');
+  let histogramTypePrefix = '';
+  if (esIndex.tier_access_level === 'regular') {
+    histogramTypePrefix = 'RegularAccess';
+  }
 
   let AggsNestedTypeSchema = '';
   while (fieldAggsNestedTypeMap.length > 0) {
@@ -207,7 +215,7 @@ const getAggregationSchemaForOneNestedIndex = (esInstance, esIndex) => {
       ${propsKey}: NestedHistogramFor${firstLetterUpperCase(propsKey)}`;
         }
         return `
-    ${propsKey}: ${getAggsHistogramName(esgqlTypeMapping[entryType])}`;
+    ${propsKey}: ${histogramTypePrefix + getAggsHistogramName(esgqlTypeMapping[entryType])}`;
       })}
 }`;
     }

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -60,7 +60,7 @@ const getObjNameFromESIndex = (esIndex) => {
   // Choosing to replace hyphens with the string "_DASH_".
   // It's self-documenting, lends well to readability, and the
   // likelihood of a user naming an ES index with the string _DASH_ is low.
-  esTypeObjName = esTypeObjName.replaceAll('-', '_DASH_');
+  esTypeObjName = esTypeObjName.replace(/-/g, '_DASH_');
   return esTypeObjName;
 };
 

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -262,7 +262,7 @@ export const getHistogramSchemas = () => {
   const textHistogramSchema = getTextHistogramSchema(false);
 
   const regularAccessTextHistogramSchema = getTextHistogramSchema(true);
-  
+
   const numberHistogramSchema = getNumberHistogramSchema(false);
 
   const regularAccessNumberHistogramSchema = getNumberHistogramSchema(true);
@@ -270,7 +270,7 @@ export const getHistogramSchemas = () => {
   const histogramSchemas = [textHistogramSchema, regularAccessTextHistogramSchema, numberHistogramSchema, regularAccessNumberHistogramSchema].join('\n');
 
   return histogramSchemas;
-}
+};
 
 export const buildSchemaString = (esConfig, esInstance) => {
   const querySchema = getQuerySchema(esConfig);
@@ -308,7 +308,7 @@ export const buildSchemaString = (esConfig, esInstance) => {
     esInstance);
 
   const histogramSchemas = getHistogramSchemas();
-  
+
   const textHistogramBucketSchema = `
     type BucketsForNestedStringAgg {
       key: String

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -146,9 +146,13 @@ const getAggregationType = (entry) => {
   return '';
 };
 
-const getAggregationSchemaForOneIndex = (esInstance, esIndex, esType) => {
+const getAggregationSchemaForOneIndex = (esInstance, esDict) => {
+  const esIndex = esDict.type;
+  const esType = esDict.type;
   let histogramTypePrefix = '';
-  if (esIndex.tier_access_level === 'regular') {
+  // eslint-disable-next-line no-console
+  console.log('>>>>> inside getAggregationSchemaForOneIndex; esIndex: ', esIndex);
+  if (Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular') {
     histogramTypePrefix = 'RegularAccess';
   }
   const esTypeObjName = firstLetterUpperCase(esType);
@@ -192,11 +196,12 @@ export const getAggregationSchema = (esConfig) => `
  * Multi-level nested fields are "flattened" level by level.
  * For each level of nested field a new type in schema is created.
  */
-const getAggregationSchemaForOneNestedIndex = (esInstance, esIndex) => {
+const getAggregationSchemaForOneNestedIndex = (esInstance, esDict) => {
+  const esIndex = esDict.type;
   const fieldGQLTypeMap = getFieldGQLTypeMapForOneIndex(esInstance, esIndex);
   const fieldAggsNestedTypeMap = fieldGQLTypeMap.filter((f) => f.esType === 'nested');
   let histogramTypePrefix = '';
-  if (esIndex.tier_access_level === 'regular') {
+  if (Object.prototype.hasOwnProperty.call(esDict, 'tier_access_level') && esDict.tier_access_level === 'regular') {
     histogramTypePrefix = 'RegularAccess';
   }
 
@@ -224,9 +229,9 @@ const getAggregationSchemaForOneNestedIndex = (esInstance, esIndex) => {
   return AggsNestedTypeSchema;
 };
 
-export const getAggregationSchemaForEachType = (esConfig, esInstance) => esConfig.indices.map((cfg) => getAggregationSchemaForOneIndex(esInstance, cfg.index, cfg.type)).join('\n');
+export const getAggregationSchemaForEachType = (esConfig, esInstance) => esConfig.indices.map((cfg) => getAggregationSchemaForOneIndex(esInstance, cfg)).join('\n');
 
-export const getAggregationSchemaForEachNestedType = (esConfig, esInstance) => esConfig.indices.map((cfg) => getAggregationSchemaForOneNestedIndex(esInstance, cfg.index)).join('\n');
+export const getAggregationSchemaForEachNestedType = (esConfig, esInstance) => esConfig.indices.map((cfg) => getAggregationSchemaForOneNestedIndex(esInstance, cfg)).join('\n');
 
 export const getMappingSchema = (esConfig) => `
     type Mapping {


### PR DESCRIPTION
This PR adds support for index-scoped tiered access settings in a manifest's guppy block. This refactor is backwards compatible with the older site-wide tiered-access level.

Jira Ticket: https://ctds-planx.atlassian.net/browse/HP-13

### New Features
- Tiered-access settings can now be optionally specified at the index-level rather than the site-wide level. This change is backwards compatible with existing site-wide tiered-access settings. Specify index-scoped tiered-access settings in the guppy block of a common's manifest. See `doc/index_scoped_tiered_access.md` for more information.