### PR TITLE
(PXP-6540): Feat/guppy format arg

### DIFF
--- a/TECHDEBT.md
+++ b/TECHDEBT.md
@@ -1,0 +1,78 @@
+# Tech debt
+
+### File Conversion Service
+Observed: January 2021
+Impact: (if this tech debt affected your work somehow, add a +1 here with a
+date and optionally a note)
++1 Christopher 2021 Jan 15 — This is an example of a +1
+##### Problem:
+The current file conversion service for Explorer (converts JSON to TSV/CSV for download)
+is located on the frontend. Ideally, we'd like to place this on the server side, however,
+Graphql does not play nice with non-object data types. The conversion service resolves the requested
+file type to a *string*, which creates some Graphql issues. You might ask, just return the string in a JSON?
+Returning the data is not the *direct* issue. We can resolve to a string and return
+the data from the API back to the user for download no problem. The issue arises because
+we have the Query page in portal that allows users to interact with Graphql (via Guppy), and
+if we were to simply return a JSON, Graphql will populate all of the user's requested query field
+properties as null. This is not ideal. Small example of this requesting with CSV format:
+```gql
+query {
+    subject(format: CSV) {
+        name
+        gender
+    }
+}
+```
+```js
+{
+    "data": {
+        "subject": [
+            {
+                "name": null,
+                "gender": null
+            }
+        ]
+    }
+}
+```
+When really, the conversion service (when moved to the server side) returned:
+```js
+{
+    "data": {
+        "subject": ['name,gender/r/n4xotff,unknown/r/nhzv1z,male']
+            }
+}
+```
+
+For now, the Query page in portal will always return JSON to avoid any null returns or impractical user experience.
+
+##### Why it was done this way:
+The conversion service as is on the frontend solves the issue of downloading TSV, CSV (and potentially
+other file types in the future). After Guppy returns the JSON from Graphql, the conversion service converts it,
+and the user has their requested file type downloaded. We do all this and preserve JSON for the Query page, so it is stable
+until we come up with a more elegant solution.
+
+##### Why this way is problematic:
+This is problematic because it hinders portability. We would like
+for the conversion service to be hit from the server side somehow.
+Better yet, we would like to keep this conversion service within Guppy.
+
+##### What the solution might be:
+Isolate the conversion service to its own environment outside of Guppy,
+perhaps an S3 bucket where users can fetch their downloaded file type.
+
+##### Why we aren't already doing the above:
+This requires extensive testing and setup and it is not
+*critical* to implement. The current conversion service in the frontend
+is sufficient and fast for now.
+
+##### Next steps:
+Explore other options besides the ones mentioned above, maybe Graphql will
+play nicer with data that resolves to non-object data types in the future.
+
+##### Other notes:
+Discussed various approaches with the team but decided this is sufficient for now.
+
+##### Design Doc:
+Visit the [design doc](https://docs.google.com/document/d/1T40eS5zQbcRESCBlyuEKgw10AdzJaZorj0JIGtBz7NI/edit?usp=sharing)
+for more information on the conversion service.

--- a/doc/download.md
+++ b/doc/download.md
@@ -1,9 +1,9 @@
 # Guppy Download Endpoint
 Guppy has another special endpoint `/download` for just fetching raw data from elasticsearch.
 
-The main difference between this `/download` endpoint and normal GraphqlQL raw data query is that the endpoint's implementation is hitting elasticsearch's scroll API to avoid the 10k row limitation of elasticsearch. This is quite useful when the data scale is over 10k rows. 
+The main difference between this `/download` endpoint and normal GraphqlQL raw data query is that the endpoint's implementation is hitting elasticsearch's scroll API to avoid the 10k row limitation of elasticsearch. This is quite useful when the data scale is over 10k rows.
 
-Currently we support following arguments for `/download` endpoint: 
+Currently we support following arguments for `/download` endpoint:
 
 | argument      | required | description                                                                     | type                                                                                              | default                                                                                                                                                                              |
 |---------------|----------|---------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -11,16 +11,17 @@ Currently we support following arguments for `/download` endpoint:
 | filter        | no       | filter to apply                                                                 | object, see [here](https://github.com/uc-cdis/guppy/blob/master/doc/queries.md#filter) for syntax | none                                                                                                                                                                                 |
 | sort          | no       | with what sort method                                                           | object                                                                                            | none                                                                                                                                                                                 |
 | fields        | no       | which fields to download                                                        | array of string                                                                                   | if not set, will return all fields                                                                                                                                                   |
+| format        | no       | file format type to return from es (see TECHDEBT.md)                            | enum: json, csv, tsv                                                                              | json                                                                                                                                                                                 |
 | accessibility | no       | only valid when using "regular" tier access mode. With which accessibility type | enum: accessible, unaccessible, all                                                               | for "regular" tier access mode, by default is "all". So in this "regular" mode if user tries to download data containing external resources, the endpoint will return 401 forbidden. |
 
 
-Example request body: 
+Example request body:
 
 ```
 {
 	"type": "subject",
 	"fields": [
-		"gender", 
+		"gender",
 		"race",
 		"file_count",
 		"subject_id",
@@ -34,7 +35,7 @@ Example request body:
 }
 ```
 
-Example result: 
+Example result:
 
 ```
 [

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -34,7 +34,7 @@ Example query:
     {
       "experiments.experimental_description": asc
     }
-  ], filter: $filter) {
+  ], filter: $filter, format: JSON) {
     subject_id
     gender
     ethnicity
@@ -132,7 +132,7 @@ Arguments:
 | offset        | starting position of query result                               | integer                             | 0       |
 | first         | return rows of query result                                     | integer                             | 10      |
 | sort          | sort method for query result                                    | JSON                                | {}      |
-| format        | downloadable file format type for query result           | ENUM: json, csv, tsv                | json    |
+| format        | downloadable file format type for query result (see [format](#format) section) | ENUM: json, csv, tsv   | json    |
 | [accessibility](#accessibility) | only valid for "regular" mode, return result by accessible type | ENUM: all, accessible, unaccessible | all     |
 | [filter](#filter)        | filter object to apply for query                                | JSON                                | {}      |
 
@@ -1269,3 +1269,11 @@ Result:
   }
 }
 ```
+
+<a name="format"></a>
+
+## Format
+To support multiple downloadable file formats for Explorer, there is a `format` arg (see [Queries](#queries) above)
+where a file type is passed into Guppy. Currently, there is support for downloads to TSV, CSV, and JSON. Due to current Graphql
+restrictions, the `format` arg is used to supply the file type to the Conversion Service, the service then converts the JSON returned
+from Guppy. The Query Page *only* returns JSON. See `TECHDEBT.md` for more details.

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -132,7 +132,7 @@ Arguments:
 | offset        | starting position of query result                               | integer                             | 0       |
 | first         | return rows of query result                                     | integer                             | 10      |
 | sort          | sort method for query result                                    | JSON                                | {}      |
-| format        | return downloadable file format type for query result           | ENUM: JSON, CSV, TSV                | JSON    |
+| format        | return downloadable file format type for query result           | ENUM: json, csv, tsv                | json    |
 | [accessibility](#accessibility) | only valid for "regular" mode, return result by accessible type | ENUM: all, accessible, unaccessible | all     |
 | [filter](#filter)        | filter object to apply for query                                | JSON                                | {}      |
 

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -132,6 +132,7 @@ Arguments:
 | offset        | starting position of query result                               | integer                             | 0       |
 | first         | return rows of query result                                     | integer                             | 10      |
 | sort          | sort method for query result                                    | JSON                                | {}      |
+| format        | return downloadable file format type for query result           | ENUM: JSON, CSV, TSV                | JSON    |
 | [accessibility](#accessibility) | only valid for "regular" mode, return result by accessible type | ENUM: all, accessible, unaccessible | all     |
 | [filter](#filter)        | filter object to apply for query                                | JSON                                | {}      |
 

--- a/doc/queries.md
+++ b/doc/queries.md
@@ -132,7 +132,7 @@ Arguments:
 | offset        | starting position of query result                               | integer                             | 0       |
 | first         | return rows of query result                                     | integer                             | 10      |
 | sort          | sort method for query result                                    | JSON                                | {}      |
-| format        | return downloadable file format type for query result           | ENUM: json, csv, tsv                | json    |
+| format        | downloadable file format type for query result           | ENUM: json, csv, tsv                | json    |
 | [accessibility](#accessibility) | only valid for "regular" mode, return result by accessible type | ENUM: all, accessible, unaccessible | all     |
 | [filter](#filter)        | filter object to apply for query                                | JSON                                | {}      |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14577,6 +14577,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
+    "papaparse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.0.tgz",
+      "integrity": "sha512-Lb7jN/4bTpiuGPrYy4tkKoUS8sTki8zacB5ke1p5zolhcSE4TlWgrlsxjrDTbG/dFVh07ck7X36hUf/b5V68pg=="
+    },
     "parallel-transform": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lodash": "^4.17.15",
     "loglevel": "^1.6.1",
     "node-fetch": "^2.3.0",
+    "papaparse": "^5.3.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -10,7 +10,7 @@ import {
   getAccessibleResources,
   askGuppyForSubAggregationData,
 } from '../Utils/queries';
-import { ENUM_ACCESSIBILITY } from '../Utils/const';
+import { ENUM_ACCESSIBILITY, FILE_FORMAT } from '../Utils/const';
 import { mergeFilters } from '../Utils/filters';
 
 /**
@@ -61,6 +61,7 @@ class GuppyWrapper extends React.Component {
       accessibleFieldObject: undefined,
       unaccessibleFieldObject: undefined,
       accessibility: ENUM_ACCESSIBILITY.ALL,
+      fileFormat: FILE_FORMAT,
       adminAppliedPreFilters: { ...this.props.adminAppliedPreFilters },
     };
   }
@@ -130,7 +131,7 @@ class GuppyWrapper extends React.Component {
    * Download all data from Guppy server and return raw data
    * This function uses current filter argument
    */
-  handleDownloadRawData(sort) {
+  handleDownloadRawData({ sort, format }) {
     return downloadDataFromGuppy(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,
@@ -140,6 +141,7 @@ class GuppyWrapper extends React.Component {
         sort: sort || [],
         filter: this.state.filter,
         accessibility: this.state.accessibility,
+        format: format in this.state.fileFormat ? format : this.state.fileFormat.JSON,
       },
     );
   }

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -10,7 +10,7 @@ import {
   getAccessibleResources,
   askGuppyForSubAggregationData,
 } from '../Utils/queries';
-import { ENUM_ACCESSIBILITY, FILE_FORMAT } from '../Utils/const';
+import { ENUM_ACCESSIBILITY, FILE_FORMATS } from '../Utils/const';
 import { mergeFilters } from '../Utils/filters';
 
 /**
@@ -61,7 +61,6 @@ class GuppyWrapper extends React.Component {
       accessibleFieldObject: undefined,
       unaccessibleFieldObject: undefined,
       accessibility: ENUM_ACCESSIBILITY.ALL,
-      fileFormat: FILE_FORMAT,
       adminAppliedPreFilters: { ...this.props.adminAppliedPreFilters },
     };
   }
@@ -141,7 +140,7 @@ class GuppyWrapper extends React.Component {
         sort: sort || [],
         filter: this.state.filter,
         accessibility: this.state.accessibility,
-        format: format in this.state.fileFormat ? format : this.state.fileFormat.JSON,
+        format: format in FILE_FORMATS ? FILE_FORMATS[format] : FILE_FORMATS.JSON,
       },
     );
   }

--- a/src/components/Utils/const.js
+++ b/src/components/Utils/const.js
@@ -5,9 +5,9 @@ export const ENUM_ACCESSIBILITY = {
 };
 
 export const FILE_FORMAT = {
-  JSON: 'JSON',
-  TSV: 'TSV',
-  CSV: 'CSV',
+  JSON: 'json',
+  TSV: 'tsv',
+  CSV: 'csv',
 };
 
 export const FILE_DELIMITERS = {

--- a/src/components/Utils/const.js
+++ b/src/components/Utils/const.js
@@ -4,13 +4,13 @@ export const ENUM_ACCESSIBILITY = {
   ALL: 'all',
 };
 
-export const FILE_FORMAT = {
+export const FILE_FORMATS = {
   JSON: 'json',
   TSV: 'tsv',
   CSV: 'csv',
 };
 
 export const FILE_DELIMITERS = {
-  TSV: '\t',
-  CSV: ',',
+  tsv: '\t',
+  csv: ',',
 };

--- a/src/components/Utils/const.js
+++ b/src/components/Utils/const.js
@@ -1,11 +1,16 @@
-export const ENUM_ACCESSIBILITY = { // eslint-disable-line import/prefer-default-export
+export const ENUM_ACCESSIBILITY = {
   ACCESSIBLE: 'accessible',
   UNACCESSIBLE: 'unaccessible',
   ALL: 'all',
 };
 
-export const FILE_FORMAT = { // File format types downloadable from portal.
+export const FILE_FORMAT = {
   JSON: 'JSON',
   TSV: 'TSV',
   CSV: 'CSV',
+};
+
+export const FILE_DELIMITERS = {
+  TSV: '\t',
+  CSV: ',',
 };

--- a/src/components/Utils/const.js
+++ b/src/components/Utils/const.js
@@ -3,3 +3,9 @@ export const ENUM_ACCESSIBILITY = { // eslint-disable-line import/prefer-default
   UNACCESSIBLE: 'unaccessible',
   ALL: 'all',
 };
+
+export const FILE_FORMAT = { // File format types downloadable from portal.
+  JSON: 'JSON',
+  TSV: 'TSV',
+  CSV: 'CSV',
+};

--- a/src/components/Utils/conversion.js
+++ b/src/components/Utils/conversion.js
@@ -1,0 +1,20 @@
+const papaparse = require('papaparse');
+const flatten = require('flat');
+
+/**
+   * This function converts JSON to specified format, JSON by default.
+   * @param {JSON} json
+   * @param {string} format
+   */
+export const jsonToFormat = (json, format) => { // eslint-disable-line import/prefer-default-export
+  const flattenedJson = flatten(json);
+  if (format === 'TSV') {
+    const config = { delimiter: '\t' };
+    return papaparse.unparse(flattenedJson, config);
+  }
+  if (format === 'CSV') {
+    const config = { delimiter: ',' };
+    return papaparse.unparse(flattenedJson, config);
+  }
+  return json;
+};

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -164,12 +164,12 @@ export const queryGuppyForRawDataAndTotalCounts = (
   format,
 ) => {
   let queryLine = 'query {';
-  if (gqlFilter || sort) {
-    queryLine = `query (${sort ? '$sort: JSON,' : ''}${gqlFilter ? '$filter: JSON' : ''}${format ? '$format: Format' : ''}) {`;
+  if (gqlFilter || sort || format) {
+    queryLine = `query (${sort ? '$sort: JSON,' : ''}${gqlFilter ? '$filter: JSON,' : ''}${format ? '$format: Format' : ''}) {`;
   }
-  let dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}${format ? ', format: $format' : ''}) {`;
-  if (gqlFilter || sort) {
-    dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''} ${format ? ' format: $format' : ''}) {`;
+  let dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}) {`;
+  if (gqlFilter || sort || format) {
+    dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}${format ? 'format: $format' : ''}) {`;
   }
   let typeAggsLine = `${type} accessibility: ${accessibility} {`;
   if (gqlFilter) {

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -167,9 +167,9 @@ export const queryGuppyForRawDataAndTotalCounts = (
   if (gqlFilter || sort) {
     queryLine = `query ($format: Format, ${sort ? '$sort: JSON,' : ''}${gqlFilter ? '$filter: JSON,' : ''}) {`;
   }
-  let dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, format: ${format}) {`;
+  let dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, format: $format) {`;
   if (gqlFilter || sort) {
-    dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, format: ${format}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
+    dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, format: $format, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
   }
   let typeAggsLine = `${type} accessibility: ${accessibility} {`;
   if (gqlFilter) {

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -161,7 +161,7 @@ export const queryGuppyForRawDataAndTotalCounts = (
   offset = 0,
   size = 20,
   accessibility = 'all',
-  format,
+  format = 'JSON',
 ) => {
   let queryLine = 'query {';
   if (gqlFilter || sort || format) {
@@ -308,7 +308,7 @@ export const askGuppyForRawData = (
   offset = 0,
   size = 20,
   accessibility = 'all',
-  format,
+  format = 'JSON',
 ) => {
   const gqlFilter = getGQLFilter(filter);
   return queryGuppyForRawDataAndTotalCounts(
@@ -346,7 +346,6 @@ export const downloadDataFromGuppy = (
 ) => {
   const SCROLL_SIZE = 10000;
   const JSON_FORMAT = format === 'JSON';
-  const fmtEnum = { format: JSON_FORMAT ? 'JSON' : format };
   if (totalCount > SCROLL_SIZE) {
     const queryBody = { type };
     if (fields) queryBody.fields = fields;
@@ -361,7 +360,7 @@ export const downloadDataFromGuppy = (
       body: JSON.stringify(queryBody),
     }).then((response) => response.json());
   }
-  return askGuppyForRawData(path, type, fields, filter, sort, 0, totalCount, accessibility, fmtEnum)
+  return askGuppyForRawData(path, type, fields, filter, sort, 0, totalCount, accessibility, format)
     .then((res) => {
       if (res && res.data && res.data[type]) {
         return JSON_FORMAT ? res.data[type] : jsonToFormat(res.data[type], format);

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -32,7 +32,7 @@ describe('Schema', () => {
         filter: JSON,
         sort: JSON,
         accessibility: Accessibility=all,
-        format: Format=JSON,
+        format: Format=json,
       ): [Subject]
       file (
         offset: Int,
@@ -40,7 +40,7 @@ describe('Schema', () => {
         filter: JSON,
         sort: JSON,
         accessibility: Accessibility=all,
-        format: Format=JSON,
+        format: Format=json,
       ): [File]
       _aggregation: Aggregation
       _mapping: Mapping

--- a/src/server/__tests__/schema.test.js
+++ b/src/server/__tests__/schema.test.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line
-import nock from 'nock'; // must import this to enable mock data by nock 
+import nock from 'nock'; // must import this to enable mock data by nock
 import {
   getQuerySchema,
   getTypesSchemas,
@@ -27,18 +27,20 @@ describe('Schema', () => {
   const expectedQuerySchemas = `
     type Query {
       subject (
-        offset: Int, 
+        offset: Int,
         first: Int,
         filter: JSON,
         sort: JSON,
         accessibility: Accessibility=all,
+        format: Format=JSON,
       ): [Subject]
       file (
-        offset: Int, 
+        offset: Int,
         first: Int,
         filter: JSON,
         sort: JSON,
         accessibility: Accessibility=all,
+        format: Format=JSON,
       ): [File]
       _aggregation: Aggregation
       _mapping: Mapping
@@ -87,14 +89,14 @@ describe('Schema', () => {
   const expectedAggregationSchema = `
     type Aggregation {
       subject (
-        filter: JSON, 
-        filterSelf: Boolean=true, 
+        filter: JSON,
+        filterSelf: Boolean=true,
         nestedAggFields:JSON,
         accessibility: Accessibility=all
       ): SubjectAggregation
       file (
-        filter: JSON, 
-        filterSelf: Boolean=true, 
+        filter: JSON,
+        filterSelf: Boolean=true,
         nestedAggFields:JSON,
         accessibility: Accessibility=all
       ): FileAggregation

--- a/src/server/resolvers.js
+++ b/src/server/resolvers.js
@@ -13,11 +13,11 @@ import { esFieldNumericTextTypeMapping, NumericTextTypeTypeEnum } from './es/con
  */
 const typeQueryResolver = (esInstance, esIndex, esType) => (parent, args, context, resolveInfo) => {
   const {
-    offset, first, filter, sort,
+    offset, first, filter, sort, format,
   } = args;
   const fields = parseResolveInfo(resolveInfo);
   return esInstance.getData({
-    esIndex, esType, fields, filter, sort, offset, size: first,
+    esIndex, esType, fields, filter, sort, offset, size: first, format,
   });
 };
 

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -58,11 +58,12 @@ const getAggsHistogramName = (gqlType) => {
 const getQuerySchemaForType = (esType) => {
   const esTypeObjName = firstLetterUpperCase(esType);
   return `${esType} (
-    offset: Int, 
+    offset: Int,
     first: Int,
     filter: JSON,
     sort: JSON,
     accessibility: Accessibility=all,
+    format: Format=JSON,
     ): [${esTypeObjName}]`;
 };
 
@@ -173,8 +174,8 @@ export const getTypesSchemas = (esConfig, esInstance) => esConfig.indices.map((c
 export const getAggregationSchema = (esConfig) => `
     type Aggregation {
       ${esConfig.indices.map((cfg) => `${cfg.type} (
-        filter: JSON, 
-        filterSelf: Boolean=true, 
+        filter: JSON,
+        filterSelf: Boolean=true,
         nestedAggFields: JSON,
         """Only used when it's regular level data commons, if set, returns aggregation data within given accessibility"""
         accessibility: Accessibility=all
@@ -247,6 +248,14 @@ export const buildSchemaString = (esConfig, esInstance) => {
     }
   `;
 
+  const formatEnum = `
+    enum Format {
+      JSON
+      TSV
+      CSV
+    }
+  `;
+
   const aggregationSchema = getAggregationSchema(esConfig);
 
   const aggregationSchemasForEachType = getAggregationSchemaForEachType(esConfig, esInstance);
@@ -293,8 +302,8 @@ export const buildSchemaString = (esConfig, esInstance) => {
   const numberHistogramSchema = `
     type ${EnumAggsHistogramName.HISTOGRAM_FOR_NUMBER} {
       histogram(
-        rangeStart: Int, 
-        rangeEnd: Int, 
+        rangeStart: Int,
+        rangeEnd: Int,
         rangeStep: Int,
         binCount: Int,
       ): [BucketsForNestedNumberAgg],
@@ -323,6 +332,7 @@ export const buildSchemaString = (esConfig, esInstance) => {
   ${matchedItemSchema}
   ${querySchema}
   ${accessibilityEnum}
+  ${formatEnum}
   ${typesSchemas}
   ${aggregationSchema}
   ${aggregationSchemasForEachType}

--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -63,7 +63,7 @@ const getQuerySchemaForType = (esType) => {
     filter: JSON,
     sort: JSON,
     accessibility: Accessibility=all,
-    format: Format=JSON,
+    format: Format=json,
     ): [${esTypeObjName}]`;
 };
 
@@ -250,9 +250,9 @@ export const buildSchemaString = (esConfig, esInstance) => {
 
   const formatEnum = `
     enum Format {
-      JSON
-      TSV
-      CSV
+      json
+      tsv
+      csv
     }
   `;
 


### PR DESCRIPTION
See [Portal](https://github.com/uc-cdis/data-portal/pull/780) for remainder of PXP-6540 changes.
Due to Graphql limitations, see TECHDEBT.md for further details about this conversion service.

### New Features
- Implemented new query argument "**format**" for Guppy to support TSV and CSV downloads from Explorer.


### Dependency updates
- Added Papaparse for conversion service

