### PR TITLE
fix: make format arg optional from query lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/guppy",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Server that support GraphQL queries on data from elasticsearch",
   "main": "src/server/server.js",
   "directories": {

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -10,7 +10,7 @@ import {
   getAccessibleResources,
   askGuppyForSubAggregationData,
 } from '../Utils/queries';
-import { ENUM_ACCESSIBILITY } from '../Utils/const';
+import { ENUM_ACCESSIBILITY, FILE_FORMATS } from '../Utils/const';
 import { mergeFilters } from '../Utils/filters';
 
 /**
@@ -131,6 +131,11 @@ class GuppyWrapper extends React.Component {
    * This function uses current filter argument
    */
   handleDownloadRawData({ sort, format }) {
+    // error handling for misconfigured format types
+    if (format && !(format in FILE_FORMATS)) {
+      // eslint-disable-next-line no-console
+      console.error(`Invalid value ${format} found for arg format!`);
+    }
     return downloadDataFromGuppy(
       this.props.guppyConfig.path,
       this.props.guppyConfig.type,

--- a/src/components/GuppyWrapper/index.jsx
+++ b/src/components/GuppyWrapper/index.jsx
@@ -10,7 +10,7 @@ import {
   getAccessibleResources,
   askGuppyForSubAggregationData,
 } from '../Utils/queries';
-import { ENUM_ACCESSIBILITY, FILE_FORMATS } from '../Utils/const';
+import { ENUM_ACCESSIBILITY } from '../Utils/const';
 import { mergeFilters } from '../Utils/filters';
 
 /**
@@ -20,9 +20,9 @@ import { mergeFilters } from '../Utils/filters';
  *   - filterConfig: configuration for ConnectedFilter component
  *   - guppyConfig: Guppy server config
  *   - onFilterChange: callback that takes filter as argument, will be
- * called everytime filter changes
+ * called every time filter changes
  *   - onReceiveNewAggsData: callback that takes aggregation results
- * as argument, will be called everytime aggregation results updated
+ * as argument, will be called every time aggregation results updated
  *
  * This wrapper will pass following data (filters, aggs, configs) to children components via prop:
  *   - aggsData: the aggregation results, format:
@@ -140,7 +140,7 @@ class GuppyWrapper extends React.Component {
         sort: sort || [],
         filter: this.state.filter,
         accessibility: this.state.accessibility,
-        format: format in FILE_FORMATS ? FILE_FORMATS[format] : FILE_FORMATS.JSON,
+        format,
       },
     );
   }

--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -161,15 +161,15 @@ export const queryGuppyForRawDataAndTotalCounts = (
   offset = 0,
   size = 20,
   accessibility = 'all',
-  format = 'json',
+  format,
 ) => {
-  let queryLine = 'query ($format: Format) {';
-  if (gqlFilter || sort) {
-    queryLine = `query ($format: Format, ${sort ? '$sort: JSON,' : ''}${gqlFilter ? '$filter: JSON,' : ''}) {`;
+  let queryLine = 'query {';
+  if (gqlFilter || sort || format) {
+    queryLine = `query (${sort ? '$sort: JSON,' : ''}${gqlFilter ? '$filter: JSON,' : ''}${format ? '$format: Format' : ''}) {`;
   }
   let dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, format: $format) {`;
-  if (gqlFilter || sort) {
-    dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, format: $format, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
+  if (gqlFilter || sort || format) {
+    dataTypeLine = `${type} (accessibility: ${accessibility}, offset: ${offset}, first: ${size}, ${format ? 'format: $format, ' : ''}, ${sort ? 'sort: $sort, ' : ''}${gqlFilter ? 'filter: $filter,' : ''}) {`;
   }
   let typeAggsLine = `${type} accessibility: ${accessibility} {`;
   if (gqlFilter) {
@@ -187,7 +187,8 @@ export const queryGuppyForRawDataAndTotalCounts = (
     }
   }`;
   const queryBody = { query };
-  queryBody.variables = { format };
+  queryBody.variables = {};
+  if (format) queryBody.variables.format = format;
   if (gqlFilter) queryBody.variables.filter = gqlFilter;
   if (sort) queryBody.variables.sort = sort;
   return fetch(`${path}${graphqlEndpoint}`, {
@@ -307,7 +308,7 @@ export const askGuppyForRawData = (
   offset = 0,
   size = 20,
   accessibility = 'all',
-  format = 'json',
+  format,
 ) => {
   const gqlFilter = getGQLFilter(filter);
   return queryGuppyForRawDataAndTotalCounts(
@@ -340,11 +341,11 @@ export const downloadDataFromGuppy = (
     filter,
     sort,
     accessibility,
-    format = 'json',
+    format,
   },
 ) => {
   const SCROLL_SIZE = 10000;
-  const JSON_FORMAT = format === 'json';
+  const JSON_FORMAT = (format === 'json' || format === undefined);
   if (totalCount > SCROLL_SIZE) {
     const queryBody = { type };
     if (fields) queryBody.fields = fields;


### PR DESCRIPTION
Make `format` to be optional in query strings issued by Guppy for backward compatibility, so newer Portal can work with old Guppy if don't need the export to CSV/TSV feature deployed

Companion PR: https://github.com/uc-cdis/data-portal/pull/790

### Bug Fixes
- Make `format` to be optional in query strings issued by Guppy for backward compatibility 


