### PR TITLE
Fix nested query bug

### DIFF
--- a/src/server/es/filter.js
+++ b/src/server/es/filter.js
@@ -278,21 +278,19 @@ const getFilterObj = (
       // instead, only apply an auth filter if exists
       return getFilterObj(esInstance, esIndex, defaultAuthFilter);
     }
-    
-    var nestedFilter = getFilterObj(esInstance, esIndex, filterOpObj, 
-                           aggsField, filterSelf, defaultAuthFilter, path)
+
+    const nestedFilter = getFilterObj(esInstance, esIndex, filterOpObj,
+      aggsField, filterSelf, defaultAuthFilter, path);
     if (nestedFilter != null) {
-        resultFilterObj = {
-          nested: {
-            path,
-            query: nestedFilter, 
-          }, 
-        };
+      resultFilterObj = {
+        nested: {
+          path,
+          query: nestedFilter,
+        },
+      };
+    } else {
+      resultFilterObj = null;
     }
-    else {
-        resultFilterObj = null
-    }
-    
   } else {
     const field = Object.keys(graphqlFilterObj[topLevelOp])[0];
     if (aggsField === field && !filterSelf) {

--- a/src/server/es/filter.js
+++ b/src/server/es/filter.js
@@ -278,13 +278,21 @@ const getFilterObj = (
       // instead, only apply an auth filter if exists
       return getFilterObj(esInstance, esIndex, defaultAuthFilter);
     }
-    resultFilterObj = {
-      nested: {
-        path,
-        query: getFilterObj(esInstance, esIndex, filterOpObj,
-          aggsField, filterSelf, defaultAuthFilter, path),
-      },
-    };
+    
+    var nestedFilter = getFilterObj(esInstance, esIndex, filterOpObj, 
+                           aggsField, filterSelf, defaultAuthFilter, path)
+    if (nestedFilter != null) {
+        resultFilterObj = {
+          nested: {
+            path,
+            query: nestedFilter, 
+          }, 
+        };
+    }
+    else {
+        resultFilterObj = null
+    }
+    
   } else {
     const field = Object.keys(graphqlFilterObj[topLevelOp])[0];
     if (aggsField === field && !filterSelf) {


### PR DESCRIPTION
When a nested filter is selected in the Exploration page and the aggregation on the same field is requested a null value is assigned to the nested query, which is not a permissible value in ES which returns 400.

### Bug Fixes
- Fixed a bug causing incorrectly putting `null` into filters that contain nested fields