### PR TITLE
Catch errors while querying total counts

### DIFF
--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -398,7 +398,12 @@ export const askGuppyForTotalCounts = (
     },
     body: JSON.stringify(queryBody),
   }).then((response) => response.json())
-    .then((response) => response.data._aggregation[type]._totalCount)
+    .then((response) => {
+      if (response.errors) {
+        throw new Error(`Error during download ${response.errors}`);
+      }
+      return response.data._aggregation[type]._totalCount;
+    })
     .catch((err) => {
       throw new Error(`Error during download ${err}`);
     });


### PR DESCRIPTION
Catch error "cannot read property of undefined (reading '_aggregation')" and log it for easier debugging

### Improvements
- Catch errors while querying total counts
