### PR TITLE
fix: add extra then in the chain to resolve response from fetch

### DIFF
--- a/src/components/Utils/queries.js
+++ b/src/components/Utils/queries.js
@@ -361,7 +361,9 @@ export const downloadDataFromGuppy = (
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(queryBody),
-    }).then((res) => (JSON_FORMAT ? res.json() : jsonToFormat(res.json(), format)));
+    })
+      .then((r) => r.json())
+      .then((res) => (JSON_FORMAT ? res : jsonToFormat(res, format)));
   }
   return askGuppyForRawData(path, type, fields, filter, sort, 0, totalCount, accessibility, format)
     .then((res) => {


### PR DESCRIPTION
Not sure how it works, seems like Promise inside ternary operator doesn't work as expected, so either extra then or await before ternary operator

Jira Ticket: [MIDRC-58](https://ctds-planx.atlassian.net/browse/MIDRC-58)

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
* proper resolving for promise

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
