### PR TITLE
PXP-11248 PXP-11258 using POST auth/mapping instead of GET to support client credentials authentication

### DIFF
--- a/src/server/__mocks__/mockDataFromES.js
+++ b/src/server/__mocks__/mockDataFromES.js
@@ -210,7 +210,7 @@ const mockResourcePath = () => {
 const mockArborist = () => {
   nock(config.arboristEndpoint)
     .persist()
-    .get('/auth/mapping')
+    .post('/auth/mapping')
     .reply(200, {
       'internal-project-1': [ // accessible
         {

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -20,22 +20,27 @@ class ArboristClient {
         method: 'POST',
         headers,
       },
-    ).catch( (error) => {
-      log.error(error.status);
-      if (error.status == 400) {
-        // Retry with GET instead of POST. Older version of Arborist POST auth/mapping 
-        // didn't support token authentication.
-        // This catch block can be removed in a little while, when it will likely not cause issues
-        return fetch(
-          resourcesEndpoint,
-          {
-            method: 'GET',
-            headers,
-          },
-        )
-      }
-    }).then(
-      (response) => response.json(),
+    ).then(
+      (response) => { 
+        if (response.status == 400) {
+          // Retry with GET instead of POST. Older version of Arborist POST auth/mapping 
+          // didn't support token authentication.
+          // This catch block can be removed in a little while, when it will likely not cause issues
+          return fetch(
+            resourcesEndpoint,
+            {
+              method: 'GET',
+              headers,
+            },
+          ).then( (response) => response.json(),)
+        } else {
+          return response.json()
+        }
+      },
+      (err) => {
+        log.error(err);
+        throw new CodedError(500, err);
+      },
     ).then(
       (result) => {
         const data = {

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -20,7 +20,21 @@ class ArboristClient {
         method: 'POST',
         headers,
       },
-    ).then(
+    ).catch( (error) => {
+      log.error(error.status);
+      if (error.status == 400) {
+        // Retry with GET instead of POST. Older version of Arborist POST auth/mapping 
+        // didn't support token authentication.
+        // This catch block can be removed in a little while, when it will likely not cause issues
+        return fetch(
+          resourcesEndpoint,
+          {
+            method: 'GET',
+            headers,
+          },
+        )
+      }
+    }).then(
       (response) => response.json(),
     ).then(
       (result) => {

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -12,39 +12,46 @@ class ArboristClient {
     // Make request to arborist for list of resources with access
     const resourcesEndpoint = `${this.baseEndpoint}/auth/mapping`;
     log.debug('[ArboristClient] listAuthorizedResources jwt: ', jwt);
-    const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
-    return fetch(
-      resourcesEndpoint,
-      {
-        method: 'GET',
-        headers,
-      },
-    ).then(
-      (response) => response.json(),
-    ).then(
-      (result) => {
-        const data = {
-          resources: [],
-        };
-        Object.keys(result).forEach((key) => {
-        // logic: you have access to a project if you have the following access:
-        // method 'read' (or '*' - all methods) to service 'guppy' (or '*' - all services)
-        // on the project resource.
-          if (result[key] && result[key].some((x) => (
-            (x.method === 'read' || x.method === '*')
-          && (x.service === 'guppy' || x.service === '*')
-          ))) {
-            data.resources.push(key);
-          }
-        });
-        log.debug('[ArboristClient] data: ', data);
-        return data;
-      },
-      (err) => {
-        log.error(err);
-        throw new CodedError(500, err);
-      },
-    );
+    if (jwt) {
+      // Enforcing the use of the JWT since we are using the arborist POST endpoint. The POST endpoint check for the presence of a token and validates it if present. 
+      // For retrocompatibility if the token is not present will use the clientID or username passed in the body. We want to avoid using the body values since that could expose 
+      // other clients or usernames that are not the logged in user ones.
+      const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
+      return fetch(
+        resourcesEndpoint,
+        {
+          method: 'POST',
+          headers,
+        },
+      ).then(
+        (response) => response.json(),
+      ).then(
+        (result) => {
+          const data = {
+            resources: [],
+          };
+          Object.keys(result).forEach((key) => {
+          // logic: you have access to a project if you have the following access:
+          // method 'read' (or '*' - all methods) to service 'guppy' (or '*' - all services)
+          // on the project resource.
+            if (result[key] && result[key].some((x) => (
+              (x.method === 'read' || x.method === '*')
+            && (x.service === 'guppy' || x.service === '*')
+            ))) {
+              data.resources.push(key);
+            }
+          });
+          log.debug('[ArboristClient] data: ', data);
+          return data;
+        },
+        (err) => {
+          log.error(err);
+          throw new CodedError(500, err);
+        },
+      );
+    } else {
+      return {"resources": []}
+    }
   }
 }
 

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -12,46 +12,44 @@ class ArboristClient {
     // Make request to arborist for list of resources with access
     const resourcesEndpoint = `${this.baseEndpoint}/auth/mapping`;
     log.debug('[ArboristClient] listAuthorizedResources jwt: ', jwt);
-    if (jwt) {
-      // Enforcing the use of the JWT since we are using the arborist POST endpoint. The POST endpoint check for the presence of a token and validates it if present. 
-      // For retrocompatibility if the token is not present will use the clientID or username passed in the body. We want to avoid using the body values since that could expose 
-      // other clients or usernames that are not the logged in user ones.
-      const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
-      return fetch(
-        resourcesEndpoint,
-        {
-          method: 'POST',
-          headers,
-        },
-      ).then(
-        (response) => response.json(),
-      ).then(
-        (result) => {
-          const data = {
-            resources: [],
-          };
-          Object.keys(result).forEach((key) => {
-          // logic: you have access to a project if you have the following access:
-          // method 'read' (or '*' - all methods) to service 'guppy' (or '*' - all services)
-          // on the project resource.
-            if (result[key] && result[key].some((x) => (
-              (x.method === 'read' || x.method === '*')
-            && (x.service === 'guppy' || x.service === '*')
-            ))) {
-              data.resources.push(key);
-            }
-          });
-          log.debug('[ArboristClient] data: ', data);
-          return data;
-        },
-        (err) => {
-          log.error(err);
-          throw new CodedError(500, err);
-        },
-      );
-    } else {
-      return {"resources": []}
-    }
+    
+    // The POST endpoint checks for the presence of a token and validates it if present. 
+    // For retrocompatibility if the token is not present will use the clientID or username passed in the body. 
+    // We want to avoid using the body values since that could expose 
+    // other clients or usernames that are not the logged in user ones.
+    const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
+    return fetch(
+      resourcesEndpoint,
+      {
+        method: 'POST',
+        headers,
+      },
+    ).then(
+      (response) => response.json(),
+    ).then(
+      (result) => {
+        const data = {
+          resources: [],
+        };
+        Object.keys(result).forEach((key) => {
+        // logic: you have access to a project if you have the following access:
+        // method 'read' (or '*' - all methods) to service 'guppy' (or '*' - all services)
+        // on the project resource.
+          if (result[key] && result[key].some((x) => (
+            (x.method === 'read' || x.method === '*')
+          && (x.service === 'guppy' || x.service === '*')
+          ))) {
+            data.resources.push(key);
+          }
+        });
+        log.debug('[ArboristClient] data: ', data);
+        return data;
+      },
+      (err) => {
+        log.error(err);
+        throw new CodedError(500, err);
+      },
+    );
   }
 }
 

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -12,7 +12,7 @@ class ArboristClient {
     // Make request to arborist for list of resources with access
     const resourcesEndpoint = `${this.baseEndpoint}/auth/mapping`;
     log.debug('[ArboristClient] listAuthorizedResources jwt: ', jwt);
-    
+
     const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
     return fetch(
       resourcesEndpoint,
@@ -21,9 +21,9 @@ class ArboristClient {
         headers,
       },
     ).then(
-      (response) => { 
-        if (response.status == 400) {
-          // Retry with GET instead of POST. Older version of Arborist POST auth/mapping 
+      (response) => {
+        if (response.status === 400) {
+          // Retry with GET instead of POST. Older version of Arborist POST auth/mapping
           // didn't support token authentication.
           // This catch block can be removed in a little while, when it will likely not cause issues
           return fetch(
@@ -32,10 +32,9 @@ class ArboristClient {
               method: 'GET',
               headers,
             },
-          ).then( (response) => response.json(),)
-        } else {
-          return response.json()
+          ).then((res) => res.json());
         }
+        return response.json();
       },
       (err) => {
         log.error(err);

--- a/src/server/auth/arboristClient.js
+++ b/src/server/auth/arboristClient.js
@@ -13,10 +13,6 @@ class ArboristClient {
     const resourcesEndpoint = `${this.baseEndpoint}/auth/mapping`;
     log.debug('[ArboristClient] listAuthorizedResources jwt: ', jwt);
     
-    // The POST endpoint checks for the presence of a token and validates it if present. 
-    // For retrocompatibility if the token is not present will use the clientID or username passed in the body. 
-    // We want to avoid using the body values since that could expose 
-    // other clients or usernames that are not the logged in user ones.
     const headers = (jwt) ? { Authorization: `bearer ${jwt}` } : {};
     return fetch(
       resourcesEndpoint,


### PR DESCRIPTION
Depends on https://github.com/uc-cdis/arborist/pull/163

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Use POST instead of GET /auth/mapping endpoint to enable client_credentials authentication

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->

