### PR TITLE
fix apply hide number resolver to as text agg results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ RUN npm run-script prepare
 EXPOSE 3000
 EXPOSE 80
 
-CMD bash ./startServer.sh
+CMD [ "bash", "./startServer.sh" ]

--- a/devHelper/README.md
+++ b/devHelper/README.md
@@ -3,7 +3,7 @@
 ## Step.1 start elasticsearch
 Go to the repository's root directory, do:
 ```
-docker-compose -f ./devHelper/docker/esearch.yml up -d
+docker compose -f ./devHelper/docker/esearch.yml up -d
 ```
 
 ## Step.2 import mock data into elasticsearch index

--- a/src/server/middlewares/perIndexTierAccessMiddleware/index.js
+++ b/src/server/middlewares/perIndexTierAccessMiddleware/index.js
@@ -41,10 +41,12 @@ const perIndexTierAccessMiddleware = {
 if (atLeastOneIndexIsRegularAccess) {
   perIndexTierAccessMiddleware.RegularAccessHistogramForNumber = {
     histogram: hideNumberResolver(false),
+    asTextHistogram: hideNumberResolver(false),
   };
 
   perIndexTierAccessMiddleware.RegularAccessHistogramForString = {
     histogram: hideNumberResolver(false),
+    asTextHistogram: hideNumberResolver(false),
   };
 }
 

--- a/src/server/middlewares/tierAccessMiddleware/index.js
+++ b/src/server/middlewares/tierAccessMiddleware/index.js
@@ -28,9 +28,11 @@ const tierAccessMiddleware = {
   ...totalCountTypeMapping,
   HistogramForNumber: {
     histogram: hideNumberResolver(false),
+    asTextHistogram: hideNumberResolver(false),
   },
   HistogramForString: {
     histogram: hideNumberResolver(false),
+    asTextHistogram: hideNumberResolver(false),
   },
 };
 


### PR DESCRIPTION


### Bug Fixes
- Fixed a bug causing tiered access middleware didn't properly applied to aggregation results


### Deployment changes
- **Important**: all envs that has tiered access enabled should deploy a Guppy that has this fix
