### PR TITLE
Fix param ordering in server.js

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -60,7 +60,7 @@ const startServer = async () => {
 
   // simple health check endpoint
   // eslint-disable-next-line no-unused-vars
-  app.get('/_status', statusRouter, (req, res, err, next) => {
+  app.get('/_status', statusRouter, (err, req, res, next) => {
     if (err instanceof CodedError) {
       // deepcode ignore ServerLeak: no important information exists in error
       res.status(err.code).send(err.msg);


### PR DESCRIPTION
Param order was wrong on changed line, put err first.  Refer to: https://expressjs.com/en/guide/error-handling.html

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes
- Fixed param ordering in server start
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
