### PR TITLE
Add support for nested authz fields definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3688,6 +3688,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@isaacs/cliui/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
@@ -3720,6 +3743,29 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {

--- a/src/server/auth/__tests__/utils.test.js
+++ b/src/server/auth/__tests__/utils.test.js
@@ -1,7 +1,6 @@
 import { getRequestResourceListFromFilter } from '../utils';
 import config from '../../config';
 import { textAggregation } from '../../es/aggs';
-import setupMockDataEndpoint from '../../__mocks__/mockDataFromES';
 
 jest.mock('../../config');
 jest.mock('../../logger');
@@ -29,11 +28,10 @@ describe('getRequestResourceListFromFilter', () => {
 
     expect(mockTextAggregation)
       .toHaveBeenCalledWith(
-        {
-          esInstance: undefined,
+        expect.objectContaining({
           esIndex: 'testIndex',
           esType: 'testType',
-        },
+        }),
         {
           field: 'name',
           filter: { term: { key: 'value' } },
@@ -58,11 +56,10 @@ describe('getRequestResourceListFromFilter', () => {
 
     expect(mockTextAggregation)
       .toHaveBeenCalledWith(
-        {
-          esInstance: undefined,
+        expect.objectContaining({
           esIndex: 'testIndex',
           esType: 'testType',
-        },
+        }),
         {
           field: 'simpleFieldName',
           filter: { term: { key: 'anotherValue' } },
@@ -87,11 +84,10 @@ describe('getRequestResourceListFromFilter', () => {
 
     expect(mockTextAggregation)
       .toHaveBeenCalledWith(
-        {
-          esInstance: undefined,
+        expect.objectContaining({
           esIndex: 'testIndex',
           esType: 'testType',
-        },
+        }),
         {
           field: 'name',
           filter: { term: { key: 'emptyValue' } },

--- a/src/server/auth/__tests__/utils.test.js
+++ b/src/server/auth/__tests__/utils.test.js
@@ -1,0 +1,105 @@
+import { getRequestResourceListFromFilter } from '../utils';
+import config from '../../config';
+import { textAggregation } from '../../es/aggs';
+import setupMockDataEndpoint from '../../__mocks__/mockDataFromES';
+
+jest.mock('../../config');
+jest.mock('../../logger');
+jest.mock('../../es/aggs', () => ({
+  textAggregation: jest.fn(),
+}));
+
+describe('getRequestResourceListFromFilter', () => {
+  const mockTextAggregation = jest.mocked(textAggregation);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should return list of resource keys when valid filter is provided', async () => {
+    config.esConfig = { authFilterField: 'nested.field.name' };
+    mockTextAggregation.mockResolvedValue([{ key: 'resource1' }, { key: 'resource2' }]);
+
+    const result = await getRequestResourceListFromFilter(
+      'testIndex',
+      'testType',
+      { term: { key: 'value' } },
+      null,
+    );
+
+    expect(mockTextAggregation)
+      .toHaveBeenCalledWith(
+        {
+          esInstance: undefined,
+          esIndex: 'testIndex',
+          esType: 'testType',
+        },
+        {
+          field: 'name',
+          filter: { term: { key: 'value' } },
+          filterSelf: null,
+          nestedPath: 'nested.field',
+        },
+      );
+    expect(result)
+      .toEqual(['resource1', 'resource2']);
+  });
+
+  test('should handle case where no nested path is present in authFilterField', async () => {
+    config.esConfig = { authFilterField: 'simpleFieldName' };
+    mockTextAggregation.mockResolvedValue([{ key: 'resource3' }]);
+
+    const result = await getRequestResourceListFromFilter(
+      'testIndex',
+      'testType',
+      { term: { key: 'anotherValue' } },
+      null,
+    );
+
+    expect(mockTextAggregation)
+      .toHaveBeenCalledWith(
+        {
+          esInstance: undefined,
+          esIndex: 'testIndex',
+          esType: 'testType',
+        },
+        {
+          field: 'simpleFieldName',
+          filter: { term: { key: 'anotherValue' } },
+          filterSelf: null,
+          nestedPath: undefined,
+        },
+      );
+    expect(result)
+      .toEqual(['resource3']);
+  });
+
+  test('should return an empty array when textAggregation returns no results', async () => {
+    config.esConfig = { authFilterField: 'nested.field.name' };
+    mockTextAggregation.mockResolvedValue([]);
+
+    const result = await getRequestResourceListFromFilter(
+      'testIndex',
+      'testType',
+      { term: { key: 'emptyValue' } },
+      null,
+    );
+
+    expect(mockTextAggregation)
+      .toHaveBeenCalledWith(
+        {
+          esInstance: undefined,
+          esIndex: 'testIndex',
+          esType: 'testType',
+        },
+        {
+          field: 'name',
+          filter: { term: { key: 'emptyValue' } },
+          filterSelf: null,
+          nestedPath: 'nested.field',
+        },
+      );
+    expect(result)
+      .toEqual([]);
+  });
+});

--- a/src/server/auth/utils.js
+++ b/src/server/auth/utils.js
@@ -104,16 +104,35 @@ export const getRequestResourceListFromFilter = async (
   esType,
   filter,
   filterSelf,
-) => textAggregation(
-  { esInstance, esIndex, esType },
-  { field: config.esConfig.authFilterField, filter, filterSelf },
-).then((res) => (res.map((item) => item.key)));
+) => {
+  const authField = config.esConfig.authFilterField;
+  const dotIdx = authField.lastIndexOf('.');
+  const field = dotIdx >= 0 ? authField.slice(dotIdx + 1) : authField;
+  const nestedPath = dotIdx >= 0 ? authField.slice(0, dotIdx) : undefined;
+
+  return textAggregation(
+    { esInstance, esIndex, esType },
+    { field, filter, filterSelf, nestedPath },
+  ).then((res) => res.map((item) => item.key));
+};
 
 export const buildFilterWithResourceList = (resourceList = []) => {
-  const filter = {
+  const authField = config.esConfig.authFilterField;
+  const dotIdx = authField.lastIndexOf('.');
+  if (dotIdx >= 0) {
+    const nestedPath = authField.slice(0, dotIdx);
+    return {
+      nested: {
+        path: nestedPath,
+        IN: {
+          [authField]: [...resourceList],
+        },
+      },
+    };
+  }
+  return {
     IN: {
-      [config.esConfig.authFilterField]: [...resourceList],
+      [authField]: [...resourceList],
     },
   };
-  return filter;
 };

--- a/src/server/auth/utils.js
+++ b/src/server/auth/utils.js
@@ -124,13 +124,13 @@ export const getRequestResourceListFromFilter = async (
 
 export const buildFilterWithResourceList = (resourceList = []) => {
   const authField = config.esConfig.authFilterField;
-  const { nestedPath } = parseAuthField(authField);
+  const { nestedPath, field } = parseAuthField(authField);
   if (nestedPath) {
     return {
       nested: {
         path: nestedPath,
         IN: {
-          [authField]: [...resourceList],
+          [field]: [...resourceList],
         },
       },
     };

--- a/src/server/auth/utils.js
+++ b/src/server/auth/utils.js
@@ -99,28 +99,33 @@ export const checkIfUserCanRefreshServer = async (passedData) => {
   return adminAccess.resources ? adminAccess.resources.includes('/guppy_admin') : false;
 };
 
+const parseAuthField = (authField) => {
+  const dotIdx = authField.lastIndexOf('.');
+  return {
+    field: dotIdx >= 0 ? authField.slice(dotIdx + 1) : authField,
+    nestedPath: dotIdx >= 0 ? authField.slice(0, dotIdx) : undefined,
+  };
+};
+
 export const getRequestResourceListFromFilter = async (
   esIndex,
   esType,
   filter,
   filterSelf,
 ) => {
-  const authField = config.esConfig.authFilterField;
-  const dotIdx = authField.lastIndexOf('.');
-  const field = dotIdx >= 0 ? authField.slice(dotIdx + 1) : authField;
-  const nestedPath = dotIdx >= 0 ? authField.slice(0, dotIdx) : undefined;
-
+  const { field, nestedPath } = parseAuthField(config.esConfig.authFilterField);
   return textAggregation(
     { esInstance, esIndex, esType },
-    { field, filter, filterSelf, nestedPath },
+    {
+      field, filter, filterSelf, nestedPath,
+    },
   ).then((res) => res.map((item) => item.key));
 };
 
 export const buildFilterWithResourceList = (resourceList = []) => {
   const authField = config.esConfig.authFilterField;
-  const dotIdx = authField.lastIndexOf('.');
-  if (dotIdx >= 0) {
-    const nestedPath = authField.slice(0, dotIdx);
+  const { nestedPath } = parseAuthField(authField);
+  if (nestedPath) {
     return {
       nested: {
         path: nestedPath,

--- a/src/server/utils/__test__/utils.test.js
+++ b/src/server/utils/__test__/utils.test.js
@@ -1,8 +1,0 @@
-import { fromFieldsToSource } from '../utils';
-import UtilsData from '../__mockData__/utils.data';
-
-describe('Parse fields from GraphQL query to fields in ES query', () => {
-  test('could parse fields in GraphQL query correctly', async () => {
-    expect(fromFieldsToSource(UtilsData.parsedInfo)).toEqual(UtilsData.fields);
-  });
-});


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/MC2DP-711

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
* Adds support for nested authz fields. MC2D is using `gen3_discovery.authz` and without this addition, the query returns an error.

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
